### PR TITLE
In _increasePoolIfNeeded, check that physicalSize != optPhysicalSize

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -581,7 +581,7 @@ bound from the model object provided to the template scope):
      * @return Array
      */
     _increasePoolIfNeeded: function() {
-      if (this._physicalSize > this._optPhysicalSize) {
+      if (this._physicalSize >= this._optPhysicalSize) {
         return null;
       }
 


### PR DESCRIPTION
If the two are equal, missingItems = 0 / this._physicalAverage = NaN and the nextPhysicalCount = NaN and delta = NaN and we pass NaN to this._createPool and new Array, which throws errors.