### PR TITLE
Improve initial physical count

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -823,7 +823,7 @@ after the list became visible again. e.g.
 
         // create the initial physical items
         if (!this._physicalItems) {
-          this._physicalCount = DEFAULT_PHYSICAL_COUNT;
+          this._physicalCount = Math.min(DEFAULT_PHYSICAL_COUNT, this._virtualCount);
           this._physicalItems = this._createPool(this._physicalCount);
           this._physicalSizes = new Array(this._physicalCount);
         }


### PR DESCRIPTION
If I have an initial array of 5 items that I expect to grow in the future, then iron-list can just create those 5 physical items (like dom-repeat) instead of a fixed value of 20.
cc @kevinpschaaf 