### PR TITLE
virtual size === 0 hotfix

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -823,7 +823,7 @@ after the list became visible again. e.g.
 
         // create the initial physical items
         if (!this._physicalItems) {
-          this._physicalCount = Math.min(DEFAULT_PHYSICAL_COUNT, this._virtualCount);
+          this._physicalCount = this._virtualCount ? Math.min(DEFAULT_PHYSICAL_COUNT, this._virtualCount) : DEFAULT_PHYSICAL_COUNT;
           this._physicalItems = this._createPool(this._physicalCount);
           this._physicalSizes = new Array(this._physicalCount);
         }

--- a/iron-list.html
+++ b/iron-list.html
@@ -823,7 +823,7 @@ after the list became visible again. e.g.
 
         // create the initial physical items
         if (!this._physicalItems) {
-          this._physicalCount = this._virtualCount ? Math.min(DEFAULT_PHYSICAL_COUNT, this._virtualCount) : DEFAULT_PHYSICAL_COUNT;
+          this._physicalCount = Math.max(1, Math.min(DEFAULT_PHYSICAL_COUNT, this._virtualCount));
           this._physicalItems = this._createPool(this._physicalCount);
           this._physicalSizes = new Array(this._physicalCount);
         }


### PR DESCRIPTION
As per inline code comment on the previous commit, I've noticed a regression with taking the minimum of the default and virtual size, because in some cases  `this._virtualSize === 0`, and hence no items are displayed at all.

This is a simple patch to correct it in some cases, but doesn't address the underlying problem of why `this._virtualSize` is 0 in the first place.