### PR TITLE
resize -> iron-resize to prevent more head banging

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ bound from the model object provided to the template scope):
 
 ### Resizing
 
-`iron-list` lays out the items when it recives a notification via the `resize` event.
+`iron-list` lays out the items when it recives a notification via the `iron-resize` event.
 This event is fired by any element that implements `IronResizableBehavior`.
 
 By default, elements such as `iron-pages`, `paper-tabs` or `paper-dialog` will trigger
@@ -74,7 +74,7 @@ you might want to implement `IronResizableBehavior` or fire this event manually 
 after the list became visible again. e.g.
 
 ```js
-document.querySelector('iron-list').fire('resize');
+document.querySelector('iron-list').fire('iron-resize');
 ```
 
 ### When should `<iron-list>` be used?


### PR DESCRIPTION
The event listened for is actually `iron-resize`, not `resize`.