### PR TITLE
Modify docs in iron-list.html

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -49,35 +49,41 @@ For example, given the following `data` array:
 
 ##### data.json
 
-    [
-      {"name": "Bob"},
-      {"name": "Tim"},
-      {"name": "Mike"}
-    ]
+```js
+[
+  {"name": "Bob"},
+  {"name": "Tim"},
+  {"name": "Mike"}
+]
+```
 
 The following code would render the list (note the name and checked properties are
 bound from the model object provided to the template scope):
 
-    <template is="dom-bind">
-      <iron-ajax url="data.json" last-response="{{data}}" auto></iron-ajax>
-      <iron-list items="[[data]]" as="item">
-        <template>
-          <div>
-            Name: <span>[[item.name]]</span>
-          </div>
-        </template>
-      </iron-list>
+```html
+<template is="dom-bind">
+  <iron-ajax url="data.json" last-response="{{data}}" auto></iron-ajax>
+  <iron-list items="[[data]]" as="item">
+    <template>
+      <div>
+        Name: <span>[[item.name]]</span>
+      </div>
     </template>
+  </iron-list>
+</template>
+```
 
 ### Styling
 
 Use the `--iron-list-items-container` mixin to style the container of items, e.g.
 
-    iron-list {
-     --iron-list-items-container: {
-        margin: auto;
-      };
-    }
+```css
+iron-list {
+ --iron-list-items-container: {
+    margin: auto;
+  };
+}
+```
 
 ### Resizing
 
@@ -89,7 +95,9 @@ this event automatically. If you hide the list manually (e.g. you use `display: 
 you might want to implement `IronResizableBehavior` or fire this event manually right
 after the list became visible again. e.g.
 
-    document.querySelector('iron-list').fire('iron-resize');
+```js
+document.querySelector('iron-list').fire('iron-resize');
+```
 
 ### When should `<iron-list>` be used?
 


### PR DESCRIPTION
This commit https://github.com/PolymerElements/iron-list/commit/39d167da7e0dbb8cf96b9edde4aa59db63a7e83c was overridden because README.md is now automatically generated based on the HTML.

The intent here is to make it easier to keep our READMEs up to date, as well as make it easy for us to use consistent style, like opening the README with a link to the elements catalog.

What do you think?