### PR TITLE
fix usage of paper-styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,9 +32,10 @@
     "iron-icons": "polymerelements/iron-icons#^1.0.0",
     "paper-badge": "polymerelements/paper-badge#^1.0.0",
     "paper-toolbar": "polymerelements/paper-toolbar#^1.0.0",
+    "paper-spinner": "polymerelements/paper-spinner#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.2",
-    "web-component-tester": "*"
+    "web-component-tester": "polymer/web-component-tester#^3.4.0"
   }
 }

--- a/demo/collapse.html
+++ b/demo/collapse.html
@@ -31,7 +31,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-list.html">
 
 </head>
-<body class="fullbleed" unresolved>
+<body unresolved>
 
 <dom-module id="x-collapse">
   <template>
@@ -128,7 +128,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       .item.expanded:hover .longText::after {
         content: ' [–]';
       }
-      
+
+      .spacer {
+        @apply(--layout-flex);
+      }
+
       @media (max-width: 460px) {
         paper-toolbar .bottom.title {
           font-size: 14px;
@@ -138,7 +142,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-ajax url="data/contacts.json" last-response="{{items}}" auto></iron-ajax>
       <paper-toolbar>
         <paper-icon-button icon="arrow-back" alt="Back"></paper-icon-button>
-        <div class="flex"></div>
+        <div class="spacer"></div>
         <paper-icon-button icon="search" alt="Search"></paper-icon-button>
         <paper-icon-button icon="more-vert" alt="More options"></paper-icon-button>
         <div class="bottom title">Collapsable items using iron-list</div>

--- a/demo/external-content.html
+++ b/demo/external-content.html
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <style is="custom-style">
     :root {
-      --dark-primary-color:       #F57C00;
+      --dark-primary-color: #F57C00;
     }
 
     paper-scroll-header-panel {
@@ -60,7 +60,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     .middle-container {
       height: 100%;
+      @apply(--layout-center);
+      @apply(--layout-horizontal);
       /*margin-left: 60px;*/
+    }
+
+    .bottom-container {
+      @apply(--layout-center);
+      @apply(--layout-horizontal);
     }
 
     .bottom {
@@ -102,13 +109,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: gray;
     }
 
+    .spacer {
+      @apply(--layout-flex);
+    }
+
     /* Small */
     @media (max-width: 600px) {
       paper-toolbar.tall .title {
         font-size: 20px;
       }
     }
-    
+
     .index {
       width: 30px;
     }
@@ -128,18 +139,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       loading="{{loading}}"
       last-response="{{people}}">
     </iron-ajax>
-    <paper-scroll-header-panel class="fit" condenses keep-condensed-header>
+    <paper-scroll-header-panel condenses keep-condensed-header>
       <paper-toolbar class="tall">
         <paper-icon-button icon="arrow-back"></paper-icon-button>
-        <div class="flex"></div>
+        <div class="spacer"></div>
         <paper-icon-button icon="search"></paper-icon-button>
         <paper-icon-button icon="refresh" on-tap="refreshData"></paper-icon-button>
         <paper-icon-button icon="more-vert"></paper-icon-button>
 
-        <div class="middle middle-container center horizontal layout">
+        <div class="middle middle-container">
           <div class="title">iron-list &amp; filltext.com</div>
         </div>
-        <div class="bottom bottom-container center horizontal layout">
+        <div class="bottom bottom-container">
           <div class="bottom-title">
             <span class="length">Rows: <span>{{people.length}}</span></span>
             <paper-spinner active="{{loading}}"></paper-spinner>

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,6 +31,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-list.html">
 
   <style is="custom-style">
+    body {
+      @apply(--layout-fullbleed);
+    }
 
     paper-scroll-header-panel {
       @apply(--layout-fit);
@@ -98,18 +101,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       color: gray;
     }
 
+    .spacer {
+      @apply(--layout-flex);
+    }
+
   </style>
 
 </head>
-<body class="fullbleed" unresolved>
+<body unresolved>
 
   <template is="dom-bind">
     <iron-ajax url="data/contacts.json" last-response="{{data}}" auto></iron-ajax>
 
-    <paper-scroll-header-panel class="fit" condenses keep-condensed-header>
+    <paper-scroll-header-panel condenses keep-condensed-header>
       <paper-toolbar class="tall">
         <paper-icon-button icon="arrow-back" alt="Back"></paper-icon-button>
-        <div class="flex"></div>
+        <div class="spacer"></div>
         <paper-icon-button icon="search" alt="Search"></paper-icon-button>
         <paper-icon-button icon="more-vert" alt="More options"></paper-icon-button>
         <div class="bottom title">iron-list</div>

--- a/demo/selection.html
+++ b/demo/selection.html
@@ -36,7 +36,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <dom-module id="x-app">
 
     <style>
-
       :host {
         @apply(--layout-fit);
         @apply(--layout-vertical);
@@ -57,7 +56,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         --paper-icon-button-ink-color: white;
       }
 
-      #itemsList, 
+      #itemsList,
       #selectedItemsList {
         @apply(--layout-flex);
       }
@@ -272,7 +271,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </script>
 
 </head>
-<body class="fullbleed" unresolved>
+<style is="custom-style">
+  body {
+    @apply(--layout-fullbleed);
+  }
+</style>
+<body unresolved>
 
   <x-app></x-app>
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -16,9 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 </head>

--- a/test/different-heights.html
+++ b/test/different-heights.html
@@ -16,11 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 

--- a/test/dynamic-item-size.html
+++ b/test/dynamic-item-size.html
@@ -16,11 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 

--- a/test/hidden-list.html
+++ b/test/hidden-list.html
@@ -16,10 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 
@@ -54,7 +51,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('iron-resize', function(done) {
         list.items = buildDataSet(100);
         list.fire('iron-resize');
-       
+
         assert.notEqual(getFirstItemFromList(list).textContent, '0');
         Polymer.RenderStatus.whenReady(function() {
           container.removeAttribute('hidden');

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -16,9 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 </head>

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -16,10 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 
@@ -55,7 +52,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           var lastItem = getLastItemFromList(list);
           var lastItemHeight = lastItem.offsetHeight;
           var expectedFinalItem = container.listHeight/lastItemHeight;
-          
+
           assert.equal(list.offsetHeight, container.listHeight);
           assert.equal(lastItemHeight, 2);
           assert.equal(getLastItemFromList(list).textContent, expectedFinalItem);
@@ -80,7 +77,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             var lastItem = getLastItemFromList(list);
             var lastItemHeight = lastItem.offsetHeight;
             var expectedFinalItem = container.listHeight/lastItemHeight;
-            
+
             assert.equal(list.offsetHeight, container.listHeight);
             assert.equal(lastItemHeight, 2);
             assert.equal(getLastItemFromList(list).textContent, expectedFinalItem);

--- a/test/selection.html
+++ b/test/selection.html
@@ -16,11 +16,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
-  <script src="../../test-fixture/test-fixture-mocha.js"></script>
   <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
-  <link rel="import" href="../../test-fixture/test-fixture.html">
-  <link rel="import" href="../../paper-styles/paper-styles.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="x-list.html">
 

--- a/test/smoke/avg-worst-case.html
+++ b/test/smoke/avg-worst-case.html
@@ -22,11 +22,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../../polymer/polymer.html">
-  <link rel="import" href="../../../paper-styles/paper-styles.html">
   <link rel="import" href="../../iron-list.html">
 
   <style is="custom-style">
-
+    body {
+      @apply(--layout-fullbleed);
+    }
+    
     iron-list {
       width: 500px;
       height: 400px;
@@ -36,35 +38,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     .item {
       background-color: green;
-      border-bottom: 1px solid white; 
+      border-bottom: 1px solid white;
     }
 
   </style>
 
 </head>
-<body  class="fullbleed" unresolved>
+<body unresolved>
 
   <template is="dom-bind">
-    
-    <h1>The physical avarage is not useful in this situations</h1>
+
+    <h1>The physical average is not useful in this situations</h1>
     <p>The list is correct if it can render all the items without empty spaces.</p>
     <iron-list id="list" items="[791, 671]" as="item" style="width: 300px; height: 300px;">
       <template>
-        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span> 
+        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span>
         </div>
       </template>
     </iron-list>
 
     <iron-list id="list2" items="[791, 671]" as="item" style="width: 710px; height: 453px;">
       <template>
-        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span> 
+        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span>
         </div>
       </template>
     </iron-list>
 
     <iron-list items="[512, 256, 128, 64, 16, 16, 16, 16, 16, 16, 8, 4]" as="item" style="height: 256px;">
       <template>
-        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span> 
+        <div class="item" style$="[[_getStyle(item)]]"><span>[[index]]</span> height: <span>[[item]]</span>
         </div>
       </template>
     </iron-list>

--- a/test/smoke/physical-count.html
+++ b/test/smoke/physical-count.html
@@ -22,12 +22,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <link rel="import" href="../../../polymer/polymer.html">
-  <link rel="import" href="../../../paper-styles/paper-styles.html">
   <link rel="import" href="../../../paper-button/paper-button.html">
 
   <link rel="import" href="../../iron-list.html">
 
   <style is="custom-style">
+    body {
+      @apply(--layout-fullbleed);
+    }
 
     .item {
       background-color: green;
@@ -55,7 +57,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       z-index: 1;
     }
 
-
     .wrapper iron-list {
       position: absolute;
       top: 0;
@@ -71,7 +72,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 
 </head>
-<body class="fullbleed" unresolved>
+<body unresolved>
 
   <template is="dom-bind">
 
@@ -196,7 +197,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         Object.observe(list, function(changes) {
           var physicalCount = list._physicalCount;
-          changes.forEach(function(change) { 
+          changes.forEach(function(change) {
 
             if (change.name === '_physicalCount') {
               values.pop();


### PR DESCRIPTION
Remove any generic `paper-styles.html` imports (which didn't seem to be used anyway), and fix any usages of the classes from `iron-flex-layout`.

Also updated the tests to use the latest version of  `web-component-tester`, and removed the unneeded `test-fixture` imports.

Also, one of the demos was using `paper-spinner` but not bower installing it.