### PR TITLE
Add lastVisibleIndex property (Fixes #53).

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -106,7 +106,7 @@ visible on the screen. e.g. the page has 500 nodes, but only 20 are visible at t
 This is why we refer to it as a `virtual` list. In this case, a `dom-repeat` will still
 create 500 nodes which could slow down the web app, but `iron-list` will only create 20.
 
-However, having an `iron-list` does not mean that you can load all the data at once. 
+However, having an `iron-list` does not mean that you can load all the data at once.
 Say, you have a million records in the database, you want to split the data into pages
 so you can bring a page at the time. The page could contain 500 items, and iron-list
 will only render 20.
@@ -364,11 +364,19 @@ will only render 20.
     _physicalSizes: null,
 
     /**
-     * A cached value for the visible index.
+     * A cached value for the first visible index.
      * See `firstVisibleIndex`
      * @type {?number}
      */
     _firstVisibleIndexVal: null,
+
+    /**
+     * A cached value for the last visible index.
+     * See `lastVisibleIndex`
+     * @type {?number}
+     */
+    _lastVisibleIndexVal: null,
+
 
     /**
      * A Polymer collection for the items.
@@ -498,6 +506,29 @@ will only render 20.
       return this._firstVisibleIndexVal;
     },
 
+    /**
+     * Gets the index of the last visible item in the viewport.
+     *
+     * @type {number}
+     */
+    get lastVisibleIndex() {
+      var physicalOffset;
+
+      if (this._lastVisibleIndexVal === null) {
+        physicalOffset = this._physicalTop;
+
+        this._iterateItems(function(pidx, vidx) {
+          physicalOffset += this._physicalSizes[pidx];
+
+          if(physicalOffset <= this._scrollBottom) {
+              this._lastVisibleIndexVal = vidx;
+          }
+        });
+      }
+
+      return this._lastVisibleIndexVal;
+    },
+
     ready: function() {
       if (IOS_TOUCH_SCROLLING) {
         this._scrollListener = function() {
@@ -578,6 +609,7 @@ will only render 20.
 
       // clear cached visible index
       this._firstVisibleIndexVal = null;
+      this._lastVisibleIndexVal = null;
 
       scrollBottom = this._scrollBottom;
       physicalBottom = this._physicalBottom;
@@ -1154,6 +1186,7 @@ will only render 20.
 
       // clear cached visible index
       this._firstVisibleIndexVal = null;
+      this._lastVisibleIndexVal = null;
     },
 
     /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -91,8 +91,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getFirstItemFromList(list).textContent, scrollToItem);
         }
 
+        function checkLastVisible() {
+          var visibleItemsCount = Math.floor(viewportHeight / rowHeight);
+
+          assert.equal(list.lastVisibleIndex, scrollToItem + visibleItemsCount - 1);
+          assert.equal(getLastItemFromList(list).textContent, scrollToItem + visibleItemsCount - 1);
+        }
+
         function doneScrollDown() {
           checkFirstVisible();
+          checkLastVisible();
 
           scrollToItem = 1;
 
@@ -107,6 +115,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         function doneScrollUp() {
           checkFirstVisible();
+          checkLastVisible();
           done();
         }
 


### PR DESCRIPTION
Together with firstVisibleIndex, lastVisibleIndex enables approximation
of visible items and implementing e.g. scroll-into-view type of functionality.

The implementation itself works similarily to firstVisibleIndex, but it uses
the viewport size (through _scrollBottom) to approximate which item is the
last visible one in the viewport.