### PR TITLE
Support focus state management

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0"
+    "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
+    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0"
   },
   "devDependencies": {
     "iron-flex-layout": "polymerelements/iron-flex-layout#^1.0.0",

--- a/demo/collapse.html
+++ b/demo/collapse.html
@@ -23,6 +23,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <link rel="import" href="../../polymer/polymer.html">
   <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
+  <link rel="import" href="../../paper-styles/color.html">
   <link rel="import" href="../../paper-toolbar/paper-toolbar.html">
   <link rel="import" href="../../paper-scroll-header-panel/paper-scroll-header-panel.html">
   <link rel="import" href="../../paper-icon-button/paper-icon-button.html">
@@ -42,21 +43,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         @apply(--paper-font-common-base);
         background-color: var(--paper-grey-200, #eee);
       }
-
       paper-toolbar {
         background: var(--google-green-700);
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
         font-weight: bold;
         z-index: 1;
+        color: white;
         --paper-toolbar-title: {
           overflow: visible;
         };
       }
-
       paper-toolbar paper-icon-button {
         --paper-icon-button-ink-color: white;
       }
-
       iron-list {
         padding-top: 1px;
         padding-bottom: 16px;
@@ -70,22 +69,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           border-bottom: 1px solid #ddd;
         };
       }
-
       .item {
         @apply(--layout-horizontal);
         padding: 20px;
         background-color: white;
         border: 1px solid #ddd;
-
         cursor: pointer;
         margin-bottom: 10px;
       }
-
-      .item:focus {
-        outline: 0;
-        border-color: #666;
-      }
-
       .avatar {
         height: 40px;
         width: 40px;
@@ -93,66 +84,59 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         box-sizing: border-box;
         background-color: #DDD;
       }
-
       .pad {
         padding: 0 16px;
         @apply(--layout-flex);
         @apply(--layout-vertical);
       }
-
       .primary {
         font-size: 16px;
         font-weight: bold;
       }
-
       .shortText, .longText {
         font-size: 14px;
       }
-
       .longText {
         color: gray;
         display: none;
       }
-
       .item:hover .shortText::after {
         content: ' [+]';
         color: gray;
       }
-
       .item.expanded:hover .shortText::after {
         content: '';
       }
-
       .item.expanded .longText {
         display: block;
       }
-
       .item.expanded:hover .longText::after {
         content: ' [–]';
       }
-
       .spacer {
         @apply(--layout-flex);
       }
-
       @media (max-width: 460px) {
         paper-toolbar .bottom.title {
           font-size: 14px;
         }
       }
     </style>
+
     <iron-ajax url="data/contacts.json" last-response="{{items}}" auto></iron-ajax>
+
       <paper-toolbar>
         <paper-icon-button icon="arrow-back" alt="Back"></paper-icon-button>
         <div class="spacer"></div>
         <paper-icon-button icon="search" alt="Search"></paper-icon-button>
         <paper-icon-button icon="more-vert" alt="More options"></paper-icon-button>
-        <div class="bottom title">Collapsable items using iron-list</div>
+        <div class="bottom title">Collapsable items</div>
       </paper-toolbar>
-      <iron-list id="list" items="[[items]]" as="item">
+
+      <iron-list id="list" items="[[items]]" as="item" selection-enabled multi-selection>
         <template>
-          <div on-tap="_collapseExpand">
-            <div class$="[[getClassForItem(item, item.expanded)]]" tabindex="0">
+          <div>
+            <div class$="[[getClassForItem(item, selected)]]" tabindex$="[[tabIndex]]">
               <img class="avatar" src="[[item.image]]">
               <div class="pad">
                 <div class="primary">[[item.name]]</div>
@@ -164,32 +148,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           </div>
         </template>
       </iron-list>
+
   </template>
+
   <script>
-  HTMLImports.whenReady(function() {
+    HTMLImports.whenReady(function() {
+
       Polymer({
         is: 'x-collapse',
+
         properties: {
+
           items: {
             type: Array
           }
-        },
 
-        _collapseExpand: function(e) {
-          var list = this.$.list;
-          var index = e.model.index;
-          var isExpanded = list.items[index].expanded;
-
-          list.set('items.' + index + '.expanded', !isExpanded);
-          list.updateSizeForItem(e.model.index);
         },
 
         iconForItem: function(item) {
           return item ? (item.integer < 50 ? 'star-border' : 'star') : '';
         },
 
-        getClassForItem: function(item, expanded) {
-          return expanded ? 'item expanded' : 'item';
+        getClassForItem: function(item, selected) {
+          return selected ? 'item expanded' : 'item';
         }
       });
     });

--- a/demo/external-content.html
+++ b/demo/external-content.html
@@ -47,6 +47,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     paper-toolbar {
       background-color: var(--dark-primary-color);
+      color: white;
       --paper-toolbar-title: {
         font-size: 40px;
         margin-left: 60px;

--- a/demo/index.html
+++ b/demo/index.html
@@ -42,6 +42,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       background-color: var(--paper-grey-200, #eee);
     }
 
+    paper-toolbar {
+      color: white;
+    }
+
     paper-toolbar.tall .title {
       font-size: 40px;
       margin-left: 60px;
@@ -71,7 +75,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     .item:focus {
       outline: 0;
-      border-color: #666;
+      border-color:#666;
     }
 
     .avatar {
@@ -115,16 +119,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <paper-scroll-header-panel condenses keep-condensed-header>
       <paper-toolbar class="tall">
-        <paper-icon-button icon="arrow-back" alt="Back"></paper-icon-button>
+        <paper-icon-button icon="arrow-back" alt="Back" tabindex="1"></paper-icon-button>
         <div class="spacer"></div>
-        <paper-icon-button icon="search" alt="Search"></paper-icon-button>
-        <paper-icon-button icon="more-vert" alt="More options"></paper-icon-button>
+        <paper-icon-button icon="search" alt="Search" tabindex="1"></paper-icon-button>
+        <paper-icon-button icon="more-vert" alt="More options" tabindex="1"></paper-icon-button>
         <div class="bottom title">iron-list</div>
       </paper-toolbar>
       <iron-list items="[[data]]" as="item">
         <template>
           <div>
-            <div class="item">
+            <div class="item" tabindex$="[[tabIndex]]">
               <img class="avatar" src="[[item.image]]">
               <div class="pad">
                 <div class="primary">[[item.name]]</div>

--- a/demo/selection.html
+++ b/demo/selection.html
@@ -49,6 +49,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         background: var(--paper-pink-500);
         box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
         z-index: 1;
+        color: white;
         --paper-toolbar-title: {
           font-size: 16px;
           line-height: 16px;
@@ -73,21 +74,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         border-bottom: 1px solid #DDD;
       }
 
-      .item:hover {
-        background-color: var(--google-grey-100);
-      }
-
       .item:focus,
       .item.selected:focus {
         outline: 0;
+        background-color: #ddd;
       }
 
       .item.selected .star {
         color: var(--paper-blue-600);
-      }
-
-      .item.selected {
-        background-color: var(--google-grey-100);
       }
 
       .avatar {
@@ -95,7 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         width: 40px;
         border-radius: 20px;
         box-sizing: border-box;
-        background-color: #DDD;
+        background-color: #ddd;
       }
 
       .pad {
@@ -141,11 +135,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         white-space: nowrap;
         cursor: pointer;
         position: relative;
-      }
-
-      paper-item:focus {
-        outline: 0;
-        background-color: #ddd;
       }
 
       paper-item:hover::after {
@@ -198,7 +187,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <iron-list id="itemsList" items="[[data]]" selected-items="{{selectedItems}}" selection-enabled multi-selection>
           <template>
             <div>
-              <div tabindex="0" aria-label$="[[_getAriaLabel(item, selected)]]" class$="[[_computedClass(selected)]]">
+              <div tabindex$="[[tabIndex]]" aria-label$="Select/Deselect [[item.name]]" class$="[[_computedClass(selected)]]">
                 <img class="avatar" src="[[item.image]]">
                 <div class="pad">
                   <div class="primary">
@@ -219,7 +208,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <!-- List for the selected items -->
           <iron-list id="selectedItemsList" items="[[selectedItems]]" hidden$="[[!selectedItems.length]]">
             <template>
-              <paper-item on-tap="_unselect" tabindex="0">[[item.name]]</paper-item>
+              <paper-item tabindex$="[[tabIndex]]" on-tap="_unselect" aria-label$="Deselect [[item.name]]">[[item.name]]</paper-item>
             </template>
           </iron-list>
         </div>
@@ -269,10 +258,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
         _showSelectionChanged: function() {
           this.$.selectedItemsList.fire('resize');
-        },
-
-        _getAriaLabel: function(item, selected) {
-          return selected ? 'Deselect ' + item.name : 'Select ' + item.name;
         }
       });
 

--- a/iron-list.html
+++ b/iron-list.html
@@ -76,23 +76,12 @@ bound from the model object provided to the template scope):
 </template>
 ```
 
-### Styling
+### Accessibility
 
-Use the `--iron-list-items-container` mixin to style the container of items, e.g.
-
-```css
-iron-list {
- --iron-list-items-container: {
-    margin: auto;
-  };
-}
-```
-
-### A11y
-
-`iron-list` can manage the items' focus state automatically. For keyboard navigation,
-users can use the up and down keys to move to the previous and next items in the list.
-To enable focus management, you can bind to the `tabIndex` property. e.g.
+`iron-list` automatically manages the focus state for the items. It also provides
+a `tabIndex` property within the template scope that can be used for keyboard navigation.
+For example, users can press the up and down keys to move to previous and next
+items in the list:
 
 ```html
 <iron-list items="[[data]]" as="item">
@@ -104,6 +93,18 @@ To enable focus management, you can bind to the `tabIndex` property. e.g.
 </iron-list>
 ```
 
+### Styling
+
+You can use the `--iron-list-items-container` mixin to style the container of items:
+
+```css
+iron-list {
+ --iron-list-items-container: {
+    margin: auto;
+  };
+}
+```
+
 ### Resizing
 
 `iron-list` lays out the items when it receives a notification via the `iron-resize` event.
@@ -112,7 +113,7 @@ This event is fired by any element that implements `IronResizableBehavior`.
 By default, elements such as `iron-pages`, `paper-tabs` or `paper-dialog` will trigger
 this event automatically. If you hide the list manually (e.g. you use `display: none`)
 you might want to implement `IronResizableBehavior` or fire this event manually right
-after the list became visible again. e.g.
+after the list became visible again. For example:
 
 ```js
 document.querySelector('iron-list').fire('iron-resize');

--- a/iron-list.html
+++ b/iron-list.html
@@ -10,6 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
+<link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 
 <!--
 
@@ -34,12 +35,14 @@ layout means (e.g. the `flex` or `fit` classes).
 
 List item templates should bind to template models of the following structure:
 
-    {
-      index: 0,     // data index for this item
-      item: {       // user data corresponding to items[index]
-        /* user item data  */
-      }
-    }
+```js
+{
+  index: 0,        // index in the item array
+  selected: false, // true if the current item is selected
+  tabIndex: -1,    // a dynamically generated tabIndex for focus management
+  item: {}         // user data corresponding to items[index]
+}
+```
 
 Alternatively, you can change the property name used as data index by changing the
 `indexAs` property. The `as` property defines the name of the variable to add to the binding
@@ -66,7 +69,7 @@ bound from the model object provided to the template scope):
   <iron-list items="[[data]]" as="item">
     <template>
       <div>
-        Name: <span>[[item.name]]</span>
+        Name: [[item.name]]
       </div>
     </template>
   </iron-list>
@@ -83,6 +86,22 @@ iron-list {
     margin: auto;
   };
 }
+```
+
+### A11y
+
+`iron-list` can manage the items' focus state automatically. For keyboard navigation,
+users can use the up and down keys to move to the previous and next items in the list.
+To enable focus management, you can bind to the `tabIndex` property. e.g.
+
+```html
+<iron-list items="[[data]]" as="item">
+  <template>
+    <div tabindex$="[[tabIndex]]">
+      Name: [[item.name]]
+    </div>
+  </template>
+</iron-list>
 ```
 
 ### Resizing
@@ -166,6 +185,7 @@ will only render 20.
   var IOS_TOUCH_SCROLLING = IOS && IOS[1] >= 8;
   var DEFAULT_PHYSICAL_COUNT = 3;
   var MAX_PHYSICAL_COUNT = 500;
+  var HIDDEN_Y = '-10000px';
 
   Polymer({
 
@@ -256,11 +276,18 @@ will only render 20.
 
     behaviors: [
       Polymer.Templatizer,
-      Polymer.IronResizableBehavior
+      Polymer.IronResizableBehavior,
+      Polymer.IronA11yKeysBehavior
     ],
 
     listeners: {
       'iron-resize': '_resizeHandler'
+    },
+
+    keyBindings: {
+      'up': '_didMoveUp',
+      'down': '_didMoveDown',
+      'enter': '_didEnter'
     },
 
     /**
@@ -401,6 +428,22 @@ will only render 20.
     _maxPages: 3,
 
     /**
+     * The currently focused item index.
+     */
+    _focusedIndex: 0,
+
+    /**
+     * The the item that is focused if it is moved offscreen.
+     */
+    _offscreenFocusedItem: null,
+
+    /**
+     * The item that backfills the `_offscreenFocusedItem` in the physical items
+     * list when that item is moved offscreen.
+     */
+    _focusBackfillItem: null,
+
+    /**
      * The bottom of the physical content.
      */
     get _physicalBottom() {
@@ -535,13 +578,14 @@ will only render 20.
     },
 
     ready: function() {
-      if (IOS_TOUCH_SCROLLING) {
-        this._scrollListener = function() {
+      this._ensureTemplatized();
+
+      this.addEventListener('focus', this._didFocus.bind(this), true);
+
+      this._scrollListener = IOS_TOUCH_SCROLLING ?
+        function() {
           requestAnimationFrame(this._scrollHandler.bind(this));
-        }.bind(this);
-      } else {
-        this._scrollListener = this._scrollHandler.bind(this);
-      }
+        }.bind(this) : this._scrollHandler.bind(this);
     },
 
     /**
@@ -709,12 +753,16 @@ will only render 20.
      * @param {!Array<number>=} movingUp
      */
     _update: function(itemSet, movingUp) {
+      // manage focus
+      if (this._isIndexRendered(this._focusedIndex)) {
+        this._restoreFocusedItem();
+      } else {
+        this._creatFocusBackfillItem();
+      }
       // update models
       this._assignModels(itemSet);
-
       // measure heights
       this._updateMetrics(itemSet);
-
       // adjust offset after measuring
       if (movingUp) {
         while (movingUp.length) {
@@ -723,10 +771,8 @@ will only render 20.
       }
       // update the position of the items
       this._positionItems();
-
       // set the scroller size
       this._updateScrollerSize();
-
       // increase the pool of physical items
       this._increasePoolIfNeeded();
     },
@@ -737,8 +783,6 @@ will only render 20.
     _createPool: function(size) {
       var physicalItems = new Array(size);
 
-      this._ensureTemplatized();
-
       for (var i = 0; i < size; i++) {
         var inst = this.stamp(null);
         // First element child is item; Safari doesn't support children[0]
@@ -746,7 +790,6 @@ will only render 20.
         physicalItems[i] = inst.root.querySelector('*');
         Polymer.dom(this).appendChild(inst.root);
       }
-
       return physicalItems;
     },
 
@@ -820,11 +863,11 @@ will only render 20.
       if (!this.ctor) {
         // Template instance props that should be excluded from forwarding
         var props = {};
-
         props.__key__ = true;
         props[this.as] = true;
         props[this.indexAs] = true;
         props[this.selectedAs] = true;
+        props.tabIndex = true;
 
         this._instanceProps = props;
         this._userTemplate = Polymer.dom(this).querySelector('template');
@@ -892,6 +935,10 @@ will only render 20.
         var key = path.substring(0, dot < 0 ? path.length : dot);
         var idx = this._physicalIndexForKey[key];
         var row = this._physicalItems[idx];
+
+        if (idx === this._focusedIndex && this._offscreenFocusedItem) {
+          row = this._offscreenFocusedItem;
+        }
         if (row) {
           var inst = row._templateInstance;
           if (dot >= 0) {
@@ -910,17 +957,18 @@ will only render 20.
      */
     _itemsChanged: function(change) {
       if (change.path === 'items') {
+
+        this._restoreFocusedItem();
         // render the new set
         this._itemsRendered = false;
-
         // update the whole set
         this._virtualStart = 0;
         this._physicalTop = 0;
         this._virtualCount = this.items ? this.items.length : 0;
+        this._focusedIndex = 0;
         this._collection = this.items ? Polymer.Collection.get(this.items) : null;
         this._physicalIndexForKey = {};
 
-        // scroll to the top
         this._resetScrollPosition(0);
 
         // create the initial physical items
@@ -929,16 +977,18 @@ will only render 20.
           this._physicalItems = this._createPool(this._physicalCount);
           this._physicalSizes = new Array(this._physicalCount);
         }
-        this._debounceTemplate(this._render);
 
+        this._debounceTemplate(this._render);
       } else if (change.path === 'items.splices') {
         // render the new set
         this._itemsRendered = false;
         this._adjustVirtualIndex(change.value.indexSplices);
         this._virtualCount = this.items ? this.items.length : 0;
-        
-        this._debounceTemplate(this._render);
 
+        if (this._focusedIndex < 0 || this._focusedIndex >= this._virtualCount) {
+          this._focusedIndex = 0;
+        }
+        this._debounceTemplate(this._render);
       } else {
         // update a single item
         this._forwardItemPath(change.path.split('.').slice(1).join('.'), change.value);
@@ -1003,10 +1053,7 @@ will only render 20.
             return rtn;
           }
         }
-
-        pidx = 0;
-
-        for (; pidx < this._physicalStart; pidx++, vidx++) {
+        for (pidx = 0; pidx < this._physicalStart; pidx++, vidx++) {
           if ((rtn = fn.call(this, pidx, vidx)) != null) {
             return rtn;
           }
@@ -1027,9 +1074,9 @@ will only render 20.
         if (item !== undefined && item !== null) {
           inst[this.as] = item;
           inst.__key__ = this._collection.getKey(item);
-          inst[this.selectedAs] =
-            /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);
+          inst[this.selectedAs] = /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);
           inst[this.indexAs] = vidx;
+          inst.tabIndex = vidx === this._focusedIndex ? 0 : -1;
           el.removeAttribute('hidden');
           this._physicalIndexForKey[inst.__key__] = pidx;
         } else {
@@ -1055,10 +1102,12 @@ will only render 20.
       Polymer.dom.flush();
 
       this._iterateItems(function(pidx, vidx) {
+
         oldPhysicalSize += this._physicalSizes[pidx] || 0;
         this._physicalSizes[pidx] = this._physicalItems[pidx].offsetHeight;
         newPhysicalSize += this._physicalSizes[pidx];
         this._physicalAverageCount += this._physicalSizes[pidx] ? 1 : 0;
+
       }, itemSet);
 
       this._physicalSize = this._physicalSize + newPhysicalSize - oldPhysicalSize;
@@ -1081,8 +1130,10 @@ will only render 20.
       var y = this._physicalTop;
 
       this._iterateItems(function(pidx) {
-        this.transform('translate3d(0, ' + y + 'px, 0)', this._physicalItems[pidx]);
+
+        this.translate3d(0, y + 'px', 0, this._physicalItems[pidx]);
         y += this._physicalSizes[pidx];
+
       });
     },
 
@@ -1147,19 +1198,15 @@ will only render 20.
       Polymer.dom.flush();
 
       var firstVisible = this.firstVisibleIndex;
-
       idx = Math.min(Math.max(idx, 0), this._virtualCount-1);
 
       // start at the previous virtual item
       // so we have a item above the first visible item
       this._virtualStart = idx - 1;
-
       // assign new models
       this._assignModels();
-
       // measure the new sizes
       this._updateMetrics();
-
       // estimate new physical offset
       this._physicalTop = this._virtualStart * this._physicalAverage;
 
@@ -1176,16 +1223,12 @@ will only render 20.
       }
       // update the scroller size
       this._updateScrollerSize(true);
-
       // update the position of the items
       this._positionItems();
-
       // set the new scroll position
       this._resetScrollPosition(this._physicalTop + this._scrollerPaddingTop + targetOffsetTop + 1);
-
       // increase the pool of physical items if needed
       this._increasePoolIfNeeded();
-
       // clear cached visible index
       this._firstVisibleIndexVal = null;
       this._lastVisibleIndexVal = null;
@@ -1230,12 +1273,14 @@ will only render 20.
      * @param {(Object|number)} item The item object or its index
      */
     _getNormalizedItem: function(item) {
-      if (typeof item === 'number') {
-        item = this.items[item];
-        if (!item) {
-          throw new RangeError('<item> not found');
+      if (this._collection.getKey(item) === undefined) {
+        if (typeof item === 'number') {
+          item = this.items[item];
+          if (!item) {
+            throw new RangeError('<item> not found');
+          }
+          return item;
         }
-      } else if (this._collection.getKey(item) === undefined) {
         throw new TypeError('<item> should be a valid item');
       }
       return item;
@@ -1258,6 +1303,7 @@ will only render 20.
         model[this.selectedAs] = true;
       }
       this.$.selector.select(item);
+      this.updateSizeForItem(item);
     },
 
     /**
@@ -1275,6 +1321,7 @@ will only render 20.
         model[this.selectedAs] = false;
       }
       this.$.selector.deselect(item);
+      this.updateSizeForItem(item);
     },
 
     /**
@@ -1320,20 +1367,15 @@ will only render 20.
      * it will remove the listener otherwise.
      */
     _selectionEnabledChanged: function(selectionEnabled) {
-      if (selectionEnabled) {
-        this.listen(this, 'tap', '_selectionHandler');
-        this.listen(this, 'keypress', '_selectionHandler');
-      } else {
-        this.unlisten(this, 'tap', '_selectionHandler');
-        this.unlisten(this, 'keypress', '_selectionHandler');
-      }
+      var handler = selectionEnabled ? this.listen : this.unlisten;
+      handler.call(this, this, 'tap', '_selectionHandler');
     },
 
     /**
      * Select an item from an event object.
      */
     _selectionHandler: function(e) {
-      if (e.type !== 'keypress' || e.keyCode === 13) {
+      if (this.selectionEnabled) {
         var model = this.modelForElement(e.target);
         if (model) {
           this.toggleSelectionForItem(model[this.as]);
@@ -1361,6 +1403,135 @@ will only render 20.
         this._updateMetrics([pidx]);
         this._positionItems();
       }
+    },
+
+    _isIndexRendered: function(idx) {
+      return idx >= this._virtualStart && idx <= this._virtualEnd;
+    },
+
+    _getPhysicalItemForIndex: function(idx, force) {
+      if (!this._collection) {
+        return null;
+      }
+      if (!this._isIndexRendered(idx)) {
+        if (force) {
+          this.scrollToIndex(idx);
+          return this._getPhysicalItemForIndex(idx, false);
+        }
+        return null;
+      }
+      var item = this._getNormalizedItem(idx);
+      var physicalItem = this._physicalItems[this._physicalIndexForKey[this._collection.getKey(item)]];
+
+      return physicalItem || null;
+    },
+
+    _focusPhysicalItem: function(idx) {
+      this._restoreFocusedItem();
+
+      var physicalItem = this._getPhysicalItemForIndex(idx, true);
+      if (!physicalItem) {
+        return;
+      }
+      var SECRET = ~(Math.random() * 100);
+      var model = physicalItem._templateInstance;
+      var focusable;
+
+      model.tabIndex = SECRET;
+      // the focusable element could be the entire physical item
+      if (physicalItem.tabIndex === SECRET) {
+       focusable = physicalItem;
+      }
+      // the focusable element could be somewhere within the physical item
+      if (!focusable) {
+        focusable = Polymer.dom(physicalItem).querySelector('[tabindex="' + SECRET + '"]');
+      }
+      // restore the tab index
+      model.tabIndex = 0;
+      focusable && focusable.focus();
+    },
+
+    _restoreFocusedItem: function() {
+      if (!this._offscreenFocusedItem) {
+        return;
+      }
+      var item = this._getNormalizedItem(this._focusedIndex);
+      var pidx = this._physicalIndexForKey[this._collection.getKey(item)];
+
+      if (pidx !== undefined) {
+        this.translate3d(0, HIDDEN_Y, 0, this._physicalItems[pidx]);
+        this._physicalItems[pidx] = this._offscreenFocusedItem;
+      }
+      this._offscreenFocusedItem = null;
+    },
+
+    _removeFocusedItem: function() {
+      if (!this._offscreenFocusedItem) {
+        return;
+      }
+      Polymer.dom(this).removeChild(this._offscreenFocusedItem);
+      this._offscreenFocusedItem = null;
+      this._focusBackfillItem = null;
+    },
+
+    _creatFocusBackfillItem: function() {
+      if (this._offscreenFocusedItem) {
+        return;
+      }
+      var item = this._getNormalizedItem(this._focusedIndex);
+      var pidx = this._physicalIndexForKey[this._collection.getKey(item)];
+
+      this._offscreenFocusedItem = this._physicalItems[pidx];
+      this.translate3d(0, HIDDEN_Y, 0, this._offscreenFocusedItem);
+
+      if (!this._focusBackfillItem) {
+        var stampedTemplate = this.stamp(null);
+        this._focusBackfillItem = stampedTemplate.root.querySelector('*');
+        Polymer.dom(this).appendChild(stampedTemplate.root);
+      }
+      this._physicalItems[pidx] = this._focusBackfillItem;
+    },
+
+    _didFocus: function(e) {
+      var targetModel = this.modelForElement(e.target);
+      var fidx = this._focusedIndex;
+
+      if (!targetModel) {
+        return;
+      }
+      this._restoreFocusedItem();
+
+      if (this.modelForElement(this._offscreenFocusedItem) === targetModel) {
+        this.scrollToIndex(fidx);
+      } else {
+        // restore tabIndex for the currently focused item
+        this._getModelFromItem(this._getNormalizedItem(fidx)).tabIndex = -1;
+        // set the tabIndex for the next focused item
+        targetModel.tabIndex = 0;
+        fidx = targetModel.index;
+        this._focusedIndex = fidx;
+        // bring the item into view
+        if (fidx < this.firstVisibleIndex || fidx > this.lastVisibleIndex) {
+          this.scrollToIndex(fidx);
+        } else {
+          this._update();
+        }
+      }
+    },
+
+    _didMoveUp: function() {
+      this._focusPhysicalItem(Math.max(0, this._focusedIndex - 1));
+    },
+
+    _didMoveDown: function() {
+      this._focusPhysicalItem(Math.min(this._virtualCount, this._focusedIndex + 1));
+    },
+
+    _didEnter: function(e) {
+      // focus the currently focused physical item
+      this._focusPhysicalItem(this._focusedIndex);
+      // toggle selection
+      this._selectionHandler(e.detail.keyboardEvent);
     }
   });
 

--- a/test/focus.html
+++ b/test/focus.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-list test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="helpers.html">
+  <link rel="import" href="x-list.html">
+</head>
+<body>
+
+  <test-fixture id="trivialList">
+    <template>
+      <x-list></x-list>
+    </template>
+  </test-fixture>
+
+<script>
+
+  suite('basic features', function() {
+    var list, container;
+
+    setup(function() {
+      container = fixture('trivialList');
+      list = container.list;
+    });
+
+    test('first item should be focusable', function(done) {
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        assert.notEqual(getFirstItemFromList(list).tabIndex, -1);
+        done();
+      });
+    });
+
+  });
+
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script>
     WCT.loadSuites([
       'basic.html',
+      'focus.html',
       'mutations.html',
       'physical-count.html',
       'hidden-list.html',

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -67,11 +67,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         function scrollBackUp() {
           simulateScroll({
             list: list,
-            contribution: 100,
+            contribution: 200,
             target: 0,
             onScrollEnd: function() {
-              assert.equal(getFirstItemFromList(list).textContent, phrase);
-              done();
+             assert.equal(getFirstItemFromList(list).textContent, phrase);
+             done();
             }
           });
         }
@@ -81,7 +81,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           // scroll down
           simulateScroll({
             list: list,
-            contribution: 100,
+            contribution: 200,
             target: setSize*rowHeight,
             onScrollEnd: function() {
               list.set('items.0.index', phrase);
@@ -109,7 +109,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           simulateScroll({
             list: list,
-            contribution: rowHeight,
+            contribution: 200,
             target: list.items.length*rowHeight,
             onScrollEnd: function() {
               assert.equal(getFirstItemFromList(list).textContent, 
@@ -149,7 +149,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           simulateScroll({
             list: list,
-            contribution: rowHeight,
+            contribution: 200,
             target: setSize*rowHeight,
             onScrollEnd: function() {
               var viewportHeight = list.offsetHeight;
@@ -204,7 +204,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
           simulateScroll({
             list: list,
-            contribution: itemHeight,
+            contribution: 200,
             target: itemHeight * list.items.length,
             onScrollEnd: function() {
               list.items = list.items.slice(0);

--- a/test/x-list.html
+++ b/test/x-list.html
@@ -43,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <iron-list style$="[[_computedListHeight(listHeight)]]" items="[[data]]" as="item" id="list">
       <template>
         <div class="item">
-          <div style$="[[_computedItemHeight(item)]]">[[_getItemValue(item, item.*, itemProp)]]</div>
+          <div style$="[[_computedItemHeight(item)]]" tabindex$="[[tabIndex]]">[[_getItemValue(item, item.*, itemProp)]]</div>
         </div>
       </template>
     </iron-list>


### PR DESCRIPTION
`iron-list` can manage the items' focus state automatically. For keyboard navigation,
users can use the up and down keys to move to the previous and next items in the list.
To enable focus management, you can bind to the `tabIndex` property. e.g.
```html
<iron-list items="[[data]]" as="item">
  <template>
    <div tabindex$="[[tabIndex]]">
      Name: [[item.name]]
    </div>
  </template>
</iron-list>
```

Also, fixes https://github.com/PolymerElements/iron-list/issues/180

cc @tgsergeant  @danbeam 