### PR TITLE
The max physical count should be a public property

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -188,7 +188,6 @@ will only render 20.
   var IOS = navigator.userAgent.match(/iP(?:hone|ad;(?: U;)? CPU) OS (\d+)/);
   var IOS_TOUCH_SCROLLING = IOS && IOS[1] >= 8;
   var DEFAULT_PHYSICAL_COUNT = 3;
-  var MAX_PHYSICAL_COUNT = 500;
   var HIDDEN_Y = '-10000px';
 
   Polymer({
@@ -203,6 +202,14 @@ will only render 20.
        */
       items: {
         type: Array
+      },
+
+      /**
+       * The max count of physical items the pool can extend to.
+       */
+      maxPhysicalCount: {
+        type: Number,
+        value: 500
       },
 
       /**
@@ -807,7 +814,7 @@ will only render 20.
       var nextPhysicalCount = Math.min(
           this._physicalCount + missingItems,
           this._virtualCount - this._virtualStart,
-          MAX_PHYSICAL_COUNT
+          Math.max(this.maxPhysicalCount, DEFAULT_PHYSICAL_COUNT)
         );
       var prevPhysicalCount = this._physicalCount;
       var delta = nextPhysicalCount - prevPhysicalCount;


### PR DESCRIPTION
The max amount of physical items the pool can extend to is stored in the local variable `MAX_PHYSICAL_COUNT`. If we make it a public property, it can be modified from the outside. That can be useful if a developer wishes to set the max physical count to a lower count, for instance, for mobile devices.