### PR TITLE
Fixes for issues #241 and #246. Details in comment.

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1240,7 +1240,7 @@ will only render 20.
     _updateGridMetrics: function() {
       this._viewportWidth = this.$.items.offsetWidth;
       // Set item width to the value of the _physicalItems offsetWidth
-      this._itemWidth = this._physicalCount > 0 ? this._physicalItems[0].offsetWidth : DEFAULT_GRID_SIZE;
+      this._itemWidth = this._physicalCount > 0 ? this._physicalItems[0].getBoundingClientRect().width : DEFAULT_GRID_SIZE;
       // Set row height to the value of the _physicalItems offsetHeight
       this._rowHeight = this._physicalCount > 0 ? this._physicalItems[0].offsetHeight : DEFAULT_GRID_SIZE;
       // If in grid mode compute how many items with exist in each row

--- a/iron-list.html
+++ b/iron-list.html
@@ -1238,7 +1238,7 @@ will only render 20.
     },
 
     _updateGridMetrics: function() {
-      this._viewportWidth = this._scrollTargetWidth;
+      this._viewportWidth = this.$.items.offsetWidth;
       // Set item width to the value of the _physicalItems offsetWidth
       this._itemWidth = this._physicalCount > 0 ? this._physicalItems[0].offsetWidth : DEFAULT_GRID_SIZE;
       // Set row height to the value of the _physicalItems offsetHeight


### PR DESCRIPTION
Fix for #241.
In the doc there is an demo of giving an margin to the items container via the --iron-list-items-container mixin. But if the viewport is measured from the scrollTarget, the _itemsPerRow calculation and the rowOffset calculation don't include the margin. Same goes for the width of an Scrollbar.

Fix for #246
The measured item width is full integer due the use of offsetWidth. 
If the viewport width is odd and the item width is in %, this is imprecise.
getBoundingClientRect().width would retrieve the exact width.