### PR TITLE
scrollToItem Redux

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "list",
     "virtual-list"
   ],
-  "version": "1.3.2",
+  "version": "1.3.3",
   "homepage": "https://github.com/PolymerElements/iron-list",
   "authors": [
     "The Polymer Authors"

--- a/iron-list.html
+++ b/iron-list.html
@@ -1349,16 +1349,26 @@ will only render 20.
         this._scrollHeight = this._estScrollHeight;
       }
     },
+
     /**
      * Scroll to a specific item in the virtual list regardless
      * of the physical items in the DOM tree.
      *
-     * @method scrollToIndex
-     * @param {number} idx The index of the item
+     * @method scrollToItem
+     * @param {(Object|number)} item The item object or its index
      */
-    scrollToIndex: function(idx) {
-      if (typeof idx !== 'number') {
-        return;
+    scrollToItem: function(item){
+      var idx = null;
+
+      if (typeof item === 'number') {
+        idx = item;
+      } else {
+        idx = this.items.indexOf(item);
+      }
+
+      //check if item is in the list
+      if(typeof idx === 'undefined' || idx < 0 || idx > this.items.length - 1){
+        return false;
       }
 
       Polymer.dom.flush();
@@ -1401,6 +1411,19 @@ will only render 20.
       // clear cached visible index
       this._firstVisibleIndexVal = null;
       this._lastVisibleIndexVal = null;
+
+      return true;
+    },
+
+    /**
+     * Scroll to a specific index in the virtual list regardless
+     * of the physical items in the DOM tree.
+     *
+     * @method scrollToIndex
+     * @param {number} idx The index of the item
+     */
+    scrollToIndex: function(idx) {
+      return this.scrollToItem(idx);
     },
 
     /**

--- a/iron-list.html
+++ b/iron-list.html
@@ -1355,17 +1355,20 @@ will only render 20.
      * of the physical items in the DOM tree.
      *
      * @method scrollToItem
-     * @param {(Object|number)} item The item object or its index
+     * @param {(Object)} item The item to be scrolled to
      */
     scrollToItem: function(item){
-      var idx = null;
+      return this.scrollToIndex(this.items.indexOf(item));
+    },
 
-      if (typeof item === 'number') {
-        idx = item;
-      } else {
-        idx = this.items.indexOf(item);
-      }
-
+    /**
+     * Scroll to a specific index in the virtual list regardless
+     * of the physical items in the DOM tree.
+     *
+     * @method scrollToIndex
+     * @param {number} idx The index of the item
+     */
+    scrollToIndex: function(idx) {
       //check if item is in the list
       if(typeof idx === 'undefined' || idx < 0 || idx > this.items.length - 1){
         return false;
@@ -1413,17 +1416,6 @@ will only render 20.
       this._lastVisibleIndexVal = null;
 
       return true;
-    },
-
-    /**
-     * Scroll to a specific index in the virtual list regardless
-     * of the physical items in the DOM tree.
-     *
-     * @method scrollToIndex
-     * @param {number} idx The index of the item
-     */
-    scrollToIndex: function(idx) {
-      return this.scrollToItem(idx);
     },
 
     /**

--- a/test/basic.html
+++ b/test/basic.html
@@ -150,6 +150,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       }, 100);
     });
 
+    test('scroll to item', function() {
+      list.items = buildDataSet(100);
+
+      setTimeout(function() {
+        list.scrollToItem(list.items[30]);
+        assert.equal(list.firstVisibleIndex, 30);
+
+        list.scrollToItem(list.items[0]);
+        assert.equal(list.firstVisibleIndex, 0);
+      }, 100);
+    });
+
     test('scroll to top', function(done) {
       list.items = buildDataSet(100);
       Polymer.dom.flush();


### PR DESCRIPTION
Refactored scrollToItem to be dependent on scrollToIndex.

Kept enhanced return semantics as they are useful when dealing with filtered lists and do not break the existing API.