### PR TITLE
Correct random access scroll changing when Grid === True. Fixes #284

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -813,7 +813,7 @@ will only render 20.
       // random access
       if (Math.abs(delta) > this._physicalSize) {
         this._physicalTop += delta;
-        recycledTiles =  Math.round(delta / this._physicalAverage);
+        recycledTiles =  Math.round(delta / this._physicalAverage) * this._itemsPerRow;
       }
       // scroll up
       else if (delta < 0) {


### PR DESCRIPTION
The `recycledTiles` were counting one per row instead of the number of rows multiplied by the `_itemsPerRow`.

Fixes #284 