### PR TITLE
Bugfix: Prevent ignoring explicitly fired iron-resize events on iOS

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1484,7 +1484,8 @@ will only render 20.
      */
     _resizeHandler: function() {
       // iOS fires the resize event when the address bar slides up
-      if (IOS && Math.abs(this._viewportHeight - this._scrollTargetHeight) < 100) {
+      var delta = Math.abs(this._viewportHeight - this._scrollTargetHeight);
+      if (IOS && delta > 0 && delta < 100) {
         return;
       }
       // In Desktop Safari 9.0.3, if the scroll bars are always shown,


### PR DESCRIPTION
iOS fires the resize event when the address bar slides up. Iron-list therefore detects those events and ignores them.
The check accidentally also filtered out all manually fired `iron-resize` events (`fire('iron-resize')`).
Explicitely firing the `iron-resize` is for example required to instruct `iron-list` to update if data was changed while the list was not visible (https://github.com/PolymerElements/iron-list/issues/279#issuecomment-236748346).