### PR TITLE
Disable the scroll event only when the list is hidden

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1493,10 +1493,12 @@ will only render 20.
       Polymer.dom.addDebouncer(this.debounce('_debounceTemplate', function() {
         this.updateViewportBoundaries();
         this._render();
-        if (this._physicalCount > 0 && this._isVisible) {
+        if (this._isVisible) {
           this.toggleScrollListener(true);
-          this._resetAverage();
-          this.scrollToIndex(this.firstVisibleIndex);
+          if (this._physicalCount > 0) {
+            this._resetAverage();
+            this.scrollToIndex(this.firstVisibleIndex);
+          }
         } else {
           this.toggleScrollListener(false);
         }


### PR DESCRIPTION
Just found out this bug. If `iron-resize` fired before the list was rendered, then the scroll listener would never be restored.