### PR TITLE
re-set item sub-properties on unhide

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1245,7 +1245,7 @@ will only render 20.
         if (item != null) {
           inst[this.as] = item;
 
-          if(item && typeof item === 'object' && !Array.isArray(item)) {
+          if(typeof item === 'object' && !Array.isArray(item)) {
             for(var prop in item) {
               if(item.hasOwnProperty(prop)) {
                 inst.set([this.as, prop], item[prop]);

--- a/iron-list.html
+++ b/iron-list.html
@@ -1244,6 +1244,15 @@ will only render 20.
         var item = this.items && this.items[vidx];
         if (item != null) {
           inst[this.as] = item;
+
+          if(item && typeof item === 'object' && !Array.isArray(item)) {
+            for(var prop in item) {
+              if(item.hasOwnProperty(prop)) {
+                inst.set([this.as, prop], item[prop]);
+              }
+            }
+          }
+
           inst.__key__ = this._collection.getKey(item);
           inst[this.selectedAs] = /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);
           inst[this.indexAs] = vidx;


### PR DESCRIPTION
This is an attempt at fixing #300 and any related issues.

Essentially, when a physical item becomes visible (hidden attribute removed), the item is set (`inst[this.as] = item`).

The problem here is that, if the item's sub-properties have changed since it was last visible, dirty checks will find that the object hasn't changed (same ref).

I've tried to fix this by iterating through an object's properties and setting each one again. Theoretically, this should be enough to notify the physical item/instance of since-changed sub-properties (as unchanged ones fail dirty check).

If possible @blasten, could you give your thoughts on this solution?

FYI the reason I didn't simply set `inst[this.as] = undefined` on hide is because a that would greatly change behaviour of iron-list. Items would then be `undefined` or an object, whereas before, they could only be an object.
