### PR TITLE
Make iron-list behave as a dumb list when parent's height is not spec…

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -663,7 +663,7 @@ will only render 20.
       if (this.grid) {
         return this._estRowsInView * this._rowHeight * this._maxPages;
       }
-      return this._viewportHeight * this._maxPages;
+      return this._viewportHeight === 0 ? Infinity : this._viewportHeight * this._maxPages;
     },
 
    /**
@@ -928,10 +928,6 @@ will only render 20.
      * @return {boolean} True if the pool was increased.
      */
     _increasePoolIfNeeded: function() {
-      // Base case 1: the list has no height.
-      if (this._viewportHeight === 0) {
-        return false;
-      }
       var self = this;
       var isClientFull = this._physicalBottom >= this._scrollBottom &&
           this._physicalTop <= this._scrollPosition;

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -92,7 +92,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         list.fire('iron-resize');
         
         flush(function() {
-          assert.isFalse(list._increasePoolIfNeeded());
+          assert.equal(list._physicalCount, 0);
           done();
         });
       });


### PR DESCRIPTION
…ified.

This allows the iron-list to behave as a dumb list where all elements are
always rendered, which is much more intuitive than previous behavior of
rendering only three elements, until the window is resized (or a resize event
was manually fired).