### PR TITLE
Fixing minor documentation error.

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -105,7 +105,7 @@ layout means (e.g. the `flex` or `fit` classes).
 <body>
   <template is="dom-bind">
     <app-toolbar>App name</app-toolbar>
-    <iron-list target="document" items="[[items]]">
+    <iron-list scroll-target="document" items="[[items]]">
       <template>
         ...
       </template>


### PR DESCRIPTION
One of the examples had a "target" attribute which should actually be "scroll-target".

Given the nature of this PR I did not create a corresponding issue.