### PR TITLE
Fixes #373 allowing support for parents to use <content> or <slot>

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -585,6 +585,13 @@ will only render 20.
     },
 
     /**
+     * The parent node for the _userTemplate.
+     */
+    get _itemsParent() {
+      return Polymer.dom(Polymer.dom(this._userTemplate).parentNode);
+    },
+
+    /**
      * The maximum scroll top value.
      */
     get _maxScrollTop() {
@@ -919,7 +926,7 @@ will only render 20.
         // First element child is item; Safari doesn't support children[0]
         // on a doc fragment.
         physicalItems[i] = inst.root.querySelector('*');
-        Polymer.dom(this).appendChild(inst.root);
+        this._itemsParent.appendChild(inst.root);
       }
       return physicalItems;
     },
@@ -1028,7 +1035,7 @@ will only render 20.
         props[this.selectedAs] = true;
         props.tabIndex = true;
         this._instanceProps = props;
-        this._userTemplate = Polymer.dom(this).querySelector('template');
+        this._userTemplate = this.queryEffectiveChildren('template');
 
         if (this._userTemplate) {
           this.templatize(this._userTemplate);
@@ -1619,7 +1626,8 @@ will only render 20.
       }
       var modelTabIndex, activeElTabIndex;
       var target = Polymer.dom(e).path[0];
-      var activeEl = Polymer.dom(this.domHost ? this.domHost.root : document).activeElement;
+      var itemsHost = this._itemsParent.node.domHost;
+      var activeEl = Polymer.dom(itemsHost ? itemsHost.root : document).activeElement;
       var physicalItem = this._physicalItems[this._getPhysicalIndex(model[this.indexAs])];
       // Safari does not focus certain form controls via mouse
       // https://bugs.webkit.org/show_bug.cgi?id=118043
@@ -1732,7 +1740,7 @@ will only render 20.
 
     _removeFocusedItem: function() {
       if (this._offscreenFocusedItem) {
-        Polymer.dom(this).removeChild(this._offscreenFocusedItem);
+        this._itemsParent.removeChild(this._offscreenFocusedItem);
       }
       this._offscreenFocusedItem = null;
       this._focusBackfillItem = null;
@@ -1751,7 +1759,7 @@ will only render 20.
         // Create a physical item.
         var stampedTemplate = this.stamp(null);
         this._focusBackfillItem = stampedTemplate.root.querySelector('*');
-        Polymer.dom(this).appendChild(stampedTemplate.root);
+        this._itemsParent.appendChild(stampedTemplate.root);
       }
       // Set the offcreen focused physical item.
       this._offscreenFocusedItem = this._physicalItems[pidx];

--- a/test/index.html
+++ b/test/index.html
@@ -28,7 +28,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'different-heights.html',
       'grid.html',
       'grid-rtl.html',
-      'bindings-host-to-item.html'
+      'bindings-host-to-item.html',
+      'template-overload.html'
     ]);
   </script>
 </body>

--- a/test/o-list.html
+++ b/test/o-list.html
@@ -1,0 +1,30 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../iron-list.html">
+
+<dom-module id="o-list">
+  <template>
+    <iron-list id="list" items="{{items}}">
+      <content>
+        <template>
+          <div class="default-template">
+            [[item.index]]
+          </div>
+        </template>
+      </content>
+    </iron-list>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({is: 'o-list'});
+</script>

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -90,7 +90,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       test('pool should not increase if the list has no size', function(done) {
         container.style.display = 'none';
         list.fire('iron-resize');
-        
+
         flush(function() {
           assert.equal(list._physicalCount, 0);
           done();

--- a/test/template-overload.html
+++ b/test/template-overload.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-list test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="helpers.html">
+  <link rel="import" href="o-list.html">
+
+</head>
+<body>
+
+  <test-fixture id="defaultTemplateList">
+    <template>
+      <o-list></o-list>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="templateOverloadList">
+    <template>
+      <o-list>
+        <template>
+          <div class="overloaded-template">[[item.index]]</div>
+        </template>
+      </o-list>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('template overloading', function() {
+      var list;
+
+      setup(function() {
+        list = fixture('templateOverloadList');
+      });
+
+      test('check physical item size', function(done) {
+        var setSize = 10;
+        list.items = buildDataSet(setSize);
+
+        flush(function() {
+          assert.equal(list.items.length, setSize);
+          done();
+        });
+      });
+
+      test('check item template', function(done) {
+        list.items = buildDataSet(1);
+
+        flush(function() {
+          assert.equal(list.$.list.$.items.querySelectorAll('.overloaded-template').length, 1);
+          done();
+        });
+      });
+
+      test('check count of physical items', function(done) {
+        var setSize = 1;
+        list.items = buildDataSet(setSize);
+
+        flush(function() {
+          assert.equal(Polymer.dom(list).querySelectorAll('*').length - 1, setSize);
+          done();
+        });
+      });
+    });
+
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
Updated the query to get the <template> element to use the effective children API which supports passing along the <template> from outside a wrapping element via <slot> or <template>

@blasten Fixes #373 