### PR TITLE
from polymerelements to PolymerElements

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,8 @@
   "ignore": [],
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",
-    "iron-resizable-behavior": "polymerelements/iron-resizable-behavior#^1.0.0",
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0",
+    "iron-resizable-behavior": "PolymerElements/iron-resizable-behavior#^1.0.0",
+    "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
     "iron-scroll-target-behavior": "PolymerElements/iron-scroll-target-behavior#^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull requests want to make this Polymer element consistent with the majority of other Polymer elements. The uppercase version "PolymerElements" is closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I checked the the "2.0-preview" branch of this Polymer element and it is already fixed there, so this pull request wants to achieve the same thing in Polymer 1.x for this element.

This pull request is a manual follow up of https://github.com/PolymerLabs/tedium/issues/47 and https://github.com/PolymerLabs/tedium/pull/48 which try to do this in an automated way, but are stuck.