### PR TITLE
child templates don't update when items updates

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1254,6 +1254,7 @@ will only render 20.
         var inst = el._templateInstance;
         var item = this.items && this.items[vidx];
         if (item != null) {
+          inst[this.as] = {};
           inst[this.as] = item;
           inst.__key__ = this._collection.getKey(item);
           inst[this.selectedAs] = /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);


### PR DESCRIPTION
When changing the array of items, the child templates should get updated, however the dirty checking doesn't trigger updates when setting an object to an existing object, so to get around the dirty checking the object needs to be cleared first.

fixes #300
@blasten