### PR TITLE
Fix: items updates trigger template updates fixes #300

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1255,6 +1255,18 @@ will only render 20.
         var item = this.items && this.items[vidx];
         if (item != null) {
           inst[this.as] = item;
+          // Grab all item based paths that the template is binding against
+          var keys = Object.keys(inst.__data__);
+          for (var i = 0; i < keys.length; i++) {
+            var key = keys[i];
+            var currValue = inst.__data__[key];
+            var newValue = inst.get(key);
+
+            // Reject paths that are defined as instance props
+            if (!this._instanceProps[key] && currValue !== newValue) {
+              inst.notifyPath(key, newValue);
+            }
+          }
           inst.__key__ = this._collection.getKey(item);
           inst[this.selectedAs] = /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);
           inst[this.indexAs] = vidx;


### PR DESCRIPTION
When updating the items array it should notify all of the templates if object properties changed so bindings get updated as well.

This should solve the issue while not triggering undefined for bindings, works for my needs as well @blasten.  I'm not a fan of the lookup on `__data__` but I couldn't find the data model that's used any other way without also getting every property on the template instance, which was less efficient when looping through it.