### PR TITLE
Fix: notify instance copy of item when items copy updates (fixes #300)

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1255,6 +1255,13 @@ will only render 20.
         var item = this.items && this.items[vidx];
         if (item != null) {
           inst[this.as] = item;
+          // Grab all top level keys for our item and trigger updates to the children.
+          var keys = Object.keys(item);
+          for (var i = 0; i < keys.length; i++) {
+            var path = 'item.' + keys[i];
+            var newValue = item[keys[i]];
+            inst.notifyPath(path, newValue);
+          }
           inst.__key__ = this._collection.getKey(item);
           inst[this.selectedAs] = /** @type {!ArraySelectorElement} */ (this.$.selector).isSelected(item);
           inst[this.indexAs] = vidx;


### PR DESCRIPTION
@blasten I found some issues with my old solution, this PR resolves #300 just the same, but also covers all of the cases in the element I was creating, including the edge cases, my only concern is that since it's running notifyPath every time (couldn't find a way to determine if there was actually a change) I'm a little concerned about the performance hit, but from my understanding, Polymer handles this for us internally via dirty checking, correct?