### PR TITLE
Add mapping for left/right and grid specific arrow key interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ per row are determined automatically based on the size of the list viewport.
 
 `iron-list` automatically manages the focus state for the items. It also provides
 a `tabIndex` property within the template scope that can be used for keyboard navigation.
-For example, users can press the up and down keys to move to previous and next
-items in the list:
+For example, users can press the up and down keys, as well as the left and right
+keys (the `grid` attribute is present), to move to focus between items in the list:
 
 ```html
 <iron-list items="[[data]]" as="item">

--- a/iron-list.html
+++ b/iron-list.html
@@ -1878,16 +1878,10 @@ will only render 20.
       this._focusPhysicalItem(this._focusedIndex - (this.grid ? this._itemsPerRow : 1));
     },
     _didMoveForward: function(e) {
-      // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
-      var destination = this._focusedIndex + (this.grid ? this._itemsPerRow : 1);
-	  // When `grid === true` move focus down one row, either
-	  // directly below or the last item of the list.
-	  if (this.grid && this._focusedIndex < (this.items.length - (this.items.length % this._itemsPerRow))) {
-		  destination = Math.min(destination, this.items.length - 1);
-	  }
       // disable scroll when pressing the down key
       e.detail.keyboardEvent.preventDefault();
-      this._focusPhysicalItem(destination);
+      // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
+      this._focusPhysicalItem(this._focusedIndex + (this.grid ? this._itemsPerRow : 1));
     },
     // When in grid mode, the use of `leftArrow` changes the focus based on the text direction
     _didMoveLeft: function(e) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1873,14 +1873,12 @@ will only render 20.
       }
     },
     // When `grid === true` the `downArrow` goes forward `this._itemsPerRow` items
-    _didMoveBackward: function(e, step) {
-      step = step || (!this.grid) ? 1 : this._itemsPerRow;
-      this._focusPhysicalItem(this._focusedIndex - step);
+    _didMoveBackward: function(e) {;
+      this._focusPhysicalItem(this._focusedIndex - (!this.grid ? 1 : this._itemsPerRow));
     },
     // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
-    _didMoveForward: function(e, step) {
-      step = step || (!this.grid) ? 1 : this._itemsPerRow;
-      var destination = this._focusedIndex + step;
+    _didMoveForward: function(e) {;
+      var destination = this._focusedIndex + (!this.grid ? 1 : this._itemsPerRow);
 	  // When `grid === true` move focus down one row, either
 	  // directly below or the last item of the list.
 	  if (this.grid && this._focusedIndex < (this.items.length - (this.items.length % this._itemsPerRow))) {
@@ -1893,14 +1891,12 @@ will only render 20.
     // When in grid mode, the use of `leftArrow` changes the focus based on the text direction
     _didMoveLeft: function(e) {
       if (!this.grid) return;
-      if (this._isRTL) this._didMoveForward(e, 1);
-      else this._didMoveBackward(e, 1);
+      this._focusPhysicalItem(this._focusedIndex + (this._isRTL ? 1 : -1));
     },
     // When in grid mode, the use of `rightArrow` changes the focus based on the text direction
     _didMoveRight: function(e) {
       if (!this.grid) return;
-      if (this._isRTL) this._didMoveBackward(e, 1);
-      else this._didMoveForward(e, 1);
+      this._focusPhysicalItem(this._focusedIndex + (this._isRTL ? -1 : 1));
     },
 
     _didEnter: function(e) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1872,20 +1872,20 @@ will only render 20.
         }
       }
     },
-    // When `grid === true` the `downArrow` goes forward `this._itemsPerRow` items
-    _didMoveBackward: function(e) {;
-      this._focusPhysicalItem(this._focusedIndex - (!this.grid ? 1 : this._itemsPerRow));
+    _didMoveBackward: function() {
+      // When `grid === true` the `downArrow` goes forward `this._itemsPerRow` items
+      this._focusPhysicalItem(this._focusedIndex - (this.grid ? this._itemsPerRow : 1));
     },
-    // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
-    _didMoveForward: function(e) {;
-      var destination = this._focusedIndex + (!this.grid ? 1 : this._itemsPerRow);
+    _didMoveForward: function(e) {
+      // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
+      var destination = this._focusedIndex + (this.grid ? this._itemsPerRow : 1);
 	  // When `grid === true` move focus down one row, either
 	  // directly below or the last item of the list.
 	  if (this.grid && this._focusedIndex < (this.items.length - (this.items.length % this._itemsPerRow))) {
 		  destination = Math.min(destination, this.items.length - 1);
 	  }
       // disable scroll when pressing the down key
-      if (e.detail.keyboardEvent.keyCode == 40) e.detail.keyboardEvent.preventDefault();
+      e.detail.keyboardEvent.preventDefault();
       this._focusPhysicalItem(destination);
     },
     // When in grid mode, the use of `leftArrow` changes the focus based on the text direction

--- a/iron-list.html
+++ b/iron-list.html
@@ -1880,7 +1880,12 @@ will only render 20.
     // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
     _didMoveForward: function(e, step) {
       step = step || (!this.grid) ? 1 : this._itemsPerRow;
-      var destination = Math.min(this._focusedIndex + step, this.items.length - 1);
+      var destination = this._focusedIndex + step;
+	  // When `grid === true` move focus down one row, either
+	  // directly below or the last item of the list.
+	  if (this.grid && this._focusedIndex < (this.items.length - (this.items.length % this._itemsPerRow))) {
+		  destination = Math.min(destination, this.items.length - 1);
+	  }
       // disable scroll when pressing the down key
       if (e.detail.keyboardEvent.keyCode == 40) e.detail.keyboardEvent.preventDefault();
       this._focusPhysicalItem(destination);

--- a/iron-list.html
+++ b/iron-list.html
@@ -425,8 +425,10 @@ will only render 20.
     ],
 
     keyBindings: {
-      'up': '_didMoveUp',
-      'down': '_didMoveDown',
+      'up': '_didMoveBackward',
+      'down': '_didMoveForward',
+      'left': '_didMoveLeft',
+      'right': '_didMoveRight',
       'enter': '_didEnter'
     },
 
@@ -1824,7 +1826,7 @@ will only render 20.
       }
       var onScreenInstance = onScreenItem._templateInstance;
       var offScreenInstance = this._offscreenFocusedItem._templateInstance;
-      // Restores the physical item only when it has the same model 
+      // Restores the physical item only when it has the same model
       // as the offscreen one. Use key for comparison since users can set
       // a new item via set('items.idx').
       if (onScreenInstance.__key__ === offScreenInstance.__key__) {
@@ -1870,15 +1872,30 @@ will only render 20.
         }
       }
     },
-
-    _didMoveUp: function() {
-      this._focusPhysicalItem(this._focusedIndex - 1);
+    // When `grid === true` the `downArrow` goes forward `this._itemsPerRow` items
+    _didMoveBackward: function(e, step) {
+      step = step || (!this.grid) ? 1 : this._itemsPerRow;
+      this._focusPhysicalItem(this._focusedIndex - step);
     },
-
-    _didMoveDown: function(e) {
+    // When `grid === true` the `upArrow` goes backward `this._itemsPerRow` items
+    _didMoveForward: function(e, step) {
+      step = step || (!this.grid) ? 1 : this._itemsPerRow;
+      var destination = Math.min(this._focusedIndex + step, this.items.length - 1);
       // disable scroll when pressing the down key
-      e.detail.keyboardEvent.preventDefault();
-      this._focusPhysicalItem(this._focusedIndex + 1);
+      if (e.detail.keyboardEvent.keyCode == 40) e.detail.keyboardEvent.preventDefault();
+      this._focusPhysicalItem(destination);
+    },
+    // When in grid mode, the use of `leftArrow` changes the focus based on the text direction
+    _didMoveLeft: function(e) {
+      if (!this.grid) return;
+      if (this._isRTL) this._didMoveForward(e, 1);
+      else this._didMoveBackward(e, 1);
+    },
+    // When in grid mode, the use of `rightArrow` changes the focus based on the text direction
+    _didMoveRight: function(e) {
+      if (!this.grid) return;
+      if (this._isRTL) this._didMoveBackward(e, 1);
+      else this._didMoveForward(e, 1);
     },
 
     _didEnter: function(e) {

--- a/test/focus.html
+++ b/test/focus.html
@@ -112,15 +112,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getFirstItemFromList(list);
         var itemToFocus = getNthItemFromList(list, 1);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 1);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
@@ -130,15 +129,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromList(list, 1);
         var itemToFocus = getFirstItemFromList(list);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 38); // up
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 0);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 

--- a/test/focus.html
+++ b/test/focus.html
@@ -89,6 +89,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('should not hide the list', function(done) {
+      container.useTabIndex = true;
       list.items = buildDataSet(100);
 
       flush(function() {
@@ -104,13 +105,50 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('list focus change with down arrow', function(done) {
+      container.useTabIndex = true;
+      list.items = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getFirstItemFromList(list);
+        var itemToFocus = getNthItemFromList(list, 1);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 1);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('list focus change with up arrow', function(done) {
+      list.items = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromList(list, 1);
+        var itemToFocus = getFirstItemFromList(list);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 38); // up
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 0);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
     test('Issue #411', function(done) {
       list.items = buildDataSet(100);
 
       Polymer.dom.flush();
 
       list.scroll(0, getFirstItemFromList(list).offsetHeight * list._physicalCount);
-     
+
       requestAnimationFrame(function() {
         setTimeout(function() {
           var lastOffscreenFocusedItem = list._offscreenFocusedItem;

--- a/test/grid-rtl.html
+++ b/test/grid-rtl.html
@@ -68,15 +68,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromRTLGrid(list, 0);
         var itemToFocus = getNthItemFromRTLGrid(list, 1);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 37); // left
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 1);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
@@ -87,15 +86,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromRTLGrid(list, 1);
         var itemToFocus = getNthItemFromRTLGrid(list, 0);
-        initialItem.addEventListener('focus', function(e) {
-            MockInteractions.pressAndReleaseKeyOn(initialItem, 39); // right
+        initialItem.focus();
+        flush(function() {
+          MockInteractions.pressAndReleaseKeyOn(list, 39); // right
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 0);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 

--- a/test/grid-rtl.html
+++ b/test/grid-rtl.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="helpers.html">
@@ -57,6 +58,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(actualVisualIndex, expectedVisualIndex);
         }
         done();
+      });
+    });
+
+    test('rtl grid focus change with right arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromRTLGrid(list, 0);
+        var itemToFocus = getNthItemFromRTLGrid(list, 1);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 37); // left
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 1);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('rtl grid focus change with left arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromRTLGrid(list, 1);
+        var itemToFocus = getNthItemFromRTLGrid(list, 0);
+        initialItem.addEventListener('focus', function(e) {
+            MockInteractions.pressAndReleaseKeyOn(initialItem, 39); // right
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 0);
+          done();
+        });
+        MockInteractions.focus(initialItem);
       });
     });
 

--- a/test/grid.html
+++ b/test/grid.html
@@ -118,10 +118,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 40); // down
           flush(function() {
-            window.requestAnimationFrame(function() {
-              assert.notEqual(itemToFocus.tabIndex, -1);
-              done();
-            });
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
           });
         });
       });

--- a/test/grid.html
+++ b/test/grid.html
@@ -125,6 +125,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('grid focus does not change with down arrow from last row but not last item', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(5);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, 3);
+        initialItem.focus();
+        flush(function() {
+          MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+          flush(function() {
+            assert.notEqual(initialItem.tabIndex, -1);
+            done();
+          });
+        });
+      });
+    });
+
     test('grid focus change with up arrow', function(done) {
       container.useTabIndex = true;
       container.data = buildDataSet(100);

--- a/test/grid.html
+++ b/test/grid.html
@@ -107,25 +107,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
-    test('grid focus change with down arrow less than one row from the end of the list', function(done) {
-      container.useTabIndex = true;
-      container.data = buildDataSet(4);
-
-      flush(function() {
-        var initialItem = getNthItemFromGrid(list, 2);
-        var itemToFocus = getNthItemFromGrid(list, 3);
-        initialItem.focus();
-        flush(function() {
-          MockInteractions.pressAndReleaseKeyOn(list, 40); // down
-          flush(function() {
-            assert.notEqual(itemToFocus.tabIndex, -1);
-            done();
-          });
-        });
-      });
-    });
-
-    test('grid focus does not change with down arrow from last row but not last item', function(done) {
+    test('grid focus does not change with down arrow from last row', function(done) {
       container.useTabIndex = true;
       container.data = buildDataSet(5);
 

--- a/test/grid.html
+++ b/test/grid.html
@@ -60,15 +60,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromGrid(list, 0);
         var itemToFocus = getNthItemFromGrid(list, 1);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 39); // right
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 1);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
@@ -79,15 +78,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromGrid(list, 1);
         var itemToFocus = getNthItemFromGrid(list, 0);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 37); // left
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 0);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
@@ -98,34 +96,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromGrid(list, 0);
         var itemToFocus = getNthItemFromGrid(list, list._itemsPerRow);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, list._itemsPerRow);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
-    test('grid focus change with down arrow less than one row from the of the list', function(done) {
+    test('grid focus change with down arrow less than one row from the end of the list', function(done) {
       container.useTabIndex = true;
-      container.data = buildDataSet(5);
+      container.data = buildDataSet(4);
 
       flush(function() {
         var initialItem = getNthItemFromGrid(list, 2);
-        var itemToFocus = getNthItemFromGrid(list, 4);
-        initialItem.addEventListener('focus', function(e) {
+        var itemToFocus = getNthItemFromGrid(list, 3);
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+          flush(function() {
+            window.requestAnimationFrame(function() {
+              assert.notEqual(itemToFocus.tabIndex, -1);
+              done();
+            });
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 4);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 
@@ -136,15 +134,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       flush(function() {
         var initialItem = getNthItemFromGrid(list, list._itemsPerRow);
         var itemToFocus = getNthItemFromGrid(list, 0);
-        initialItem.addEventListener('focus', function(e) {
+        initialItem.focus();
+        flush(function() {
           MockInteractions.pressAndReleaseKeyOn(list, 38); // up
+          flush(function() {
+            assert.notEqual(itemToFocus.tabIndex, -1);
+            done();
+          });
         });
-        itemToFocus.addEventListener('focus', function(e) {
-          var focusedIndex = list.modelForElement(e.target).index;
-          assert.equal(focusedIndex, 0);
-          done();
-        });
-        MockInteractions.focus(initialItem);
       });
     });
 

--- a/test/grid.html
+++ b/test/grid.html
@@ -15,6 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
 
   <link rel="import" href="helpers.html">
@@ -49,6 +50,101 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(getNthItemFromGrid(list, i).textContent, i);
         }
         done();
+      });
+    });
+
+    test('grid focus change with right arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, 0);
+        var itemToFocus = getNthItemFromGrid(list, 1);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 39); // right
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 1);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('grid focus change with left arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, 1);
+        var itemToFocus = getNthItemFromGrid(list, 0);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 37); // left
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 0);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('grid focus change with down arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, 0);
+        var itemToFocus = getNthItemFromGrid(list, list._itemsPerRow);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, list._itemsPerRow);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('grid focus change with down arrow less than one row from the of the list', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(5);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, 2);
+        var itemToFocus = getNthItemFromGrid(list, 4);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 40); // down
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 4);
+          done();
+        });
+        MockInteractions.focus(initialItem);
+      });
+    });
+
+    test('grid focus change with up arrow', function(done) {
+      container.useTabIndex = true;
+      container.data = buildDataSet(100);
+
+      flush(function() {
+        var initialItem = getNthItemFromGrid(list, list._itemsPerRow);
+        var itemToFocus = getNthItemFromGrid(list, 0);
+        initialItem.addEventListener('focus', function(e) {
+          MockInteractions.pressAndReleaseKeyOn(list, 38); // up
+        });
+        itemToFocus.addEventListener('focus', function(e) {
+          var focusedIndex = list.modelForElement(e.target).index;
+          assert.equal(focusedIndex, 0);
+          done();
+        });
+        MockInteractions.focus(initialItem);
       });
     });
 

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -82,9 +82,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     return document.elementFromPoint(x, y);
   }
 
+  function getNthItemFromRTLGrid(grid, n, itemSize) {
+    itemSize = itemSize || 100;
+    var gridRect = grid.getBoundingClientRect();
+    var x = gridRect.left + gridRect.width - ((n % grid._itemsPerRow) * itemSize) - (itemSize / 2);
+    var y = gridRect.top + (Math.floor(n / grid._itemsPerRow) * itemSize) + (itemSize / 2);
+    return document.elementFromPoint(x, y);
+  }
+
   function getFirstItemFromList(list) {
     var listRect = list.getBoundingClientRect();
     return document.elementFromPoint(listRect.left + 100, listRect.top + 1);
+  }
+
+  function getNthItemFromList(list, n, itemHeight) {
+    itemHeight = itemHeight || 100;
+    var listRect = list.getBoundingClientRect();
+    return document.elementFromPoint(listRect.left + 100, listRect.top + 1 + (itemHeight * n));
   }
 
   function getLastItemFromList(list) {

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -98,7 +98,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   function getNthItemFromList(list, n, itemHeight) {
     itemHeight = itemHeight || 100;
     var listRect = list.getBoundingClientRect();
-    return document.elementFromPoint(listRect.left + 100, listRect.top + 1 + (itemHeight * n));
+    var x = listRect.left + (listRect.width / 2);
+    var y = listRect.top + (n * itemHeight) + (itemHeight / 2);
+    return document.elementFromPoint(x, y);
   }
 
   function getLastItemFromList(list) {

--- a/test/x-grid.html
+++ b/test/x-grid.html
@@ -26,11 +26,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         overflow: hidden;
       }
     </style>
-    
+
     <iron-list style$="[[_computedListSize(listSize)]]" items="[[data]]" as="item" id="list" grid>
       <template>
         <div class="item">
-          <div style$="[[_computeItemSize(item)]]">[[item.index]]</div>
+          <div style$="[[_computeItemSize(item)]]" tabindex$="[[_computedTabIndex(tabIndex, useTabIndex)]]">[[item.index]]</div>
         </div>
       </template>
     </iron-list>
@@ -60,6 +60,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       pre: {
         type: Boolean
       },
+
+      useTabIndex: {
+        value: true,
+        type: Boolean
+      }
     },
 
     get list() {
@@ -75,6 +80,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     _computedListSize: function(listHeight) {
       return 'height: ' + (listHeight) + 'px;' + 'width: ' + (listHeight) + 'px;';
+    },
+
+    _computedTabIndex: function(tabIndex, useTabIndex) {
+      return useTabIndex ? tabIndex : undefined;
     }
   });
 </script>

--- a/test/x-list.html
+++ b/test/x-list.html
@@ -41,9 +41,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <iron-list style$="[[_computedListHeight(listHeight)]]" items="[[data]]" as="item" id="list">
       <template>
-        <div class="item" tabindex$="[[_computedTabIndex(tabIndex, useTabIndex)]]">
-          <div style$="[[_computedItemHeight(item)]]" tabindex="0" hidden$="[[primitive]]">[[item.index]]</div>
-          <div style$="[[_computedItemHeight(item)]]" tabindex="0" hidden$="[[!primitive]]">[[item]]</div>
+        <div class="item">
+          <div style$="[[_computedItemHeight(item)]]" tabindex$="[[_computedTabIndex(tabIndex, useTabIndex)]]" hidden$="[[primitive]]">[[item.index]]</div>
+          <div style$="[[_computedItemHeight(item)]]" tabindex$="[[_computedTabIndex(tabIndex, useTabIndex)]]" hidden$="[[!primitive]]">[[item]]</div>
         </div>
       </template>
     </iron-list>


### PR DESCRIPTION
Fixes #432

The included code extends the keyboard navigation interface to include left and right arrows when the `grid` attribute is present, and alters the response to the up and down arrows in accordance with the WAI-ARIA spec for [Layout Grids](https://www.w3.org/TR/wai-aria-practices-1.1/#h-layoutgrid).

Tests to cover this behavior is Grids, RTL Grids, and standard Lists, as well as slightly update README.md documentation is also included.