### PR TITLE
#434 correct relationship between _virtualStart and _physicalTop

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -842,9 +842,10 @@ will only render 20.
       if (Math.abs(delta) > this._physicalSize) {
         delta = delta - this._scrollOffset;
         var idxAdjustment = Math.round(delta / this._physicalAverage) * this._itemsPerRow;
-        this._physicalTop = this._physicalTop + delta;
         this._virtualStart = this._virtualStart + idxAdjustment;
         this._physicalStart = this._physicalStart + idxAdjustment;
+        // Estimate new physical offset.
+        this._physicalTop = Math.floor(this._virtualStart / this._itemsPerRow) * this._physicalAverage;
         this._update();
       } else {
         var reusables = this._getReusables(isScrollingDown);
@@ -1824,7 +1825,7 @@ will only render 20.
       }
       var onScreenInstance = onScreenItem._templateInstance;
       var offScreenInstance = this._offscreenFocusedItem._templateInstance;
-      // Restores the physical item only when it has the same model 
+      // Restores the physical item only when it has the same model
       // as the offscreen one. Use key for comparison since users can set
       // a new item via set('items.idx').
       if (onScreenInstance.__key__ === offScreenInstance.__key__) {

--- a/test/grid.html
+++ b/test/grid.html
@@ -152,18 +152,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     });
 
     test('delete a grid item when the last row should only have one item and scroll to bottom', function(done) {
-	  list.items = buildDataSet(64);
-	  Polymer.dom.flush();
-	  list.shift('items');
-	  Polymer.dom.flush();
-	  list.scroll(0, 10000000);
-	  requestAnimationFrame(function() {
-		setTimeout(function() {
-		  assert.equal(list.lastVisibleIndex, list.items.length - 1);
-		  done();
-		});
-	  });
-	});
+      list.items = buildDataSet(64);
+      Polymer.dom.flush();
+      list.shift('items');
+      Polymer.dom.flush();
+      list.scroll(0, 10000000);
+      requestAnimationFrame(function() {
+        setTimeout(function() {
+          assert.equal(list.lastVisibleIndex, list.items.length - 1);
+          done();
+        });
+      });
+    });
 
     test('Columns per row (#381)', function(done) {
       container.data = buildDataSet(1000);

--- a/test/grid.html
+++ b/test/grid.html
@@ -151,6 +151,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('delete a grid item when the last row should only have one item and scroll to bottom', function(done) {
+	  list.items = buildDataSet(64);
+	  Polymer.dom.flush();
+	  list.shift('items');
+	  Polymer.dom.flush();
+	  list.scroll(0, 10000000);
+	  requestAnimationFrame(function() {
+		setTimeout(function() {
+		  assert.equal(list.lastVisibleIndex, list.items.length - 1);
+		  done();
+		});
+	  });
+	});
+
     test('Columns per row (#381)', function(done) {
       container.data = buildDataSet(1000);
       container.itemSize = 33.3;

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -206,7 +206,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         list.scroll(0, 100);
         requestAnimationFrame(function() {
           setTimeout(function() {
-            assert.equal(list.firstVisibleIndex, 5);
+            assert.equal(list.firstVisibleIndex, 1);
             done();
           });
         });


### PR DESCRIPTION
Fixes #434 

Acquires relationship approach from `scrollToIndex` rather than an static relationship to the scroll positions. This allows for `_physicalTop` to take into account that at "scrollTop === 0" it should be the same at the top of the visible space, and at "scrollTop === maxScrollTop" it should be offset by ~0.25 pages.

I've updated the test for #389 that appeared erroneous, and added one to address the context that you have one items on the last row of a grid and after removing the last item setting the scrollTop to the last row actual set you on a row of n - 2 as seen in the JS Bin in the issue.