### PR TITLE
Add selectItems and associated tests

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1623,7 +1623,7 @@ will only render 20.
       var key = '';
       // Cast an arguments list that doesn't consist of a single array to an array
       if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
-        items = Array.from(arguments);
+        items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
       }
       items = items || this.items;
       items = items.map(function(item) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1628,11 +1628,11 @@ will only render 20.
       items = items || this.items;
       items = items.map(function(item) {
         return this._getNormalizedItem(item);
-      }.bind(this))
-      .filter(function(item) {
+      }.bind(this));
+      this.$.selector.set('selected', items);
+      items = items.filter(function(item) {
         return !(this.$.selector).isSelected(item);
       }.bind(this));
-      this.clearSelection();
       this.$.selector.set('selected', items);
       this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
       for (var i = 0, l = items.length; i < l; i++) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1633,7 +1633,6 @@ will only render 20.
       items = items.filter(function(item) {
         return !(this.$.selector).isSelected(item);
       }.bind(this));
-      this.$.selector.set('selected', items);
       this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
       for (var i = 0, l = items.length; i < l; i++) {
         item = items[i];

--- a/iron-list.html
+++ b/iron-list.html
@@ -1607,6 +1607,47 @@ will only render 20.
       this.updateSizeForItem(item);
     },
 
+
+    /**
+     * Select the array of list items provided or
+	 * select the entire list.
+     *
+     * @method selectItems
+     * @param {array} items The array of item objects or indexes
+     */
+    selectItems: function(items) {
+      var item = {};
+      var model = {};
+      var skey = '';
+      var icol = Polymer.Collection.get((this.$.selector).items);
+      var key = '';
+      // Cast an arguments list that doesn't consist of a single array to an array
+      if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
+        items = Array.from(arguments);
+      }
+      items = items || this.items;
+      items = items.map(function(item) {
+        return this._getNormalizedItem(item);
+      }.bind(this))
+      .filter(function(item) {
+        return !(this.$.selector).isSelected(item);
+      }.bind(this));
+      this.clearSelection();
+      this.$.selector.set('selected', items);
+      this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
+      for (var i = 0, l = items.length; i < l; i++) {
+        item = items[i];
+        model = this._getModelFromItem(item);
+        if (model) {
+          model[this.selectedAs] = true;
+        }
+        key = icol.getKey(item);
+        skey = (this.$.selector)._selectedColl.getKey(item);
+        (this.$.selector).linkPaths("selected." + skey, "items." + key);
+        this.updateSizeForItem(item);
+      }
+    },
+
     /**
      * Select or deselect a given item depending on whether the item
      * has already been selected.
@@ -1824,7 +1865,7 @@ will only render 20.
       }
       var onScreenInstance = onScreenItem._templateInstance;
       var offScreenInstance = this._offscreenFocusedItem._templateInstance;
-      // Restores the physical item only when it has the same model 
+      // Restores the physical item only when it has the same model
       // as the offscreen one. Use key for comparison since users can set
       // a new item via set('items.idx').
       if (onScreenInstance.__key__ === offScreenInstance.__key__) {

--- a/test/selection.html
+++ b/test/selection.html
@@ -458,6 +458,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         list.selectItems.apply(list, argumentsToSelect);
         assert.equal(list.selectedItems.length, argumentsToSelect.length);
       });
+
+      test('select items: single', function() {
+        container.useTabIndex = false;
+        list.items = buildDataSet(100);
+        list.multiSelection = true;
+        Polymer.dom.flush();
+        assert.isArray(list.selectedItems);
+        assert.equal(list.selectedItems.length, 0);
+        list.selectItems(4);
+        assert.equal(list.selectedItems.length, 1);
+      });
     });
 
   </script>

--- a/test/selection.html
+++ b/test/selection.html
@@ -423,6 +423,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         MockInteractions.tap(item);
         assert.isNotNull(list.selectedItem);
       });
+
+      test('select items: all', function() {
+        container.useTabIndex = false;
+        list.items = buildDataSet(5000);
+        list.multiSelection = true;
+        Polymer.dom.flush();
+        assert.isArray(list.selectedItems);
+        assert.equal(list.selectedItems.length, 0);
+        list.selectItems();
+        assert.equal(list.selectedItems.length, 5000);
+      });
+
+      test('select items: array', function() {
+        container.useTabIndex = false;
+        list.items = buildDataSet(100);
+        list.multiSelection = true;
+        Polymer.dom.flush();
+        assert.isArray(list.selectedItems);
+        assert.equal(list.selectedItems.length, 0);
+        var arrayToSelect = [0,3,7,9,30,39,41,42,55,60,67,68,71,82,88,90,97];
+        list.selectItems(arrayToSelect);
+        assert.equal(list.selectedItems.length, arrayToSelect.length);
+      });
+
+      test('select items: arguments', function() {
+        container.useTabIndex = false;
+        list.items = buildDataSet(100);
+        list.multiSelection = true;
+        Polymer.dom.flush();
+        assert.isArray(list.selectedItems);
+        assert.equal(list.selectedItems.length, 0);
+        var argumentsToSelect = [0,3,7,9,30,39,41,42,55,60,67,68,71,82,88,90,97];
+        list.selectItems.apply(list, argumentsToSelect);
+        assert.equal(list.selectedItems.length, argumentsToSelect.length);
+      });
     });
 
   </script>


### PR DESCRIPTION
Fixes #436

As mentioned in the issue above, this may actually be an `array-selector` issue more than an `iron-list` issue, but as this specific code seems better managed in `iron-list` than in user space code as initially noted with the potential solution in #124, I figured this was a good step in getting this conversation more definitively completed.

This code adds a `selectItems` method that selects the entirety of `this.items` when no arguments are found, or casts the content of arguments into an Array such that they can be selected in batch regardless of them being an array, a single item, or a list of items.

Tests for "select items: all", "select items: array" (sending the method an array), "select items: arguments" (sending the batch as an arguments list), and "select items: single" to maintain this functionality moving forward.