### PR TITLE
Blur when focused item is removed; add focusItem method

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1680,6 +1680,10 @@ will only render 20.
       return (this._physicalStart + (idx - this._virtualStart)) % this._physicalCount;
     },
 
+    focusItem: function(idx) {
+      this._focusPhysicalItem(idx);
+    },
+
     _focusPhysicalItem: function(idx) {
       if (idx < 0 || idx >= this._virtualCount) {
         return;
@@ -1718,6 +1722,7 @@ will only render 20.
       this._focusedItem = null;
       this._focusedVirtualIndex = -1;
       this._focusedPhysicalIndex = -1;
+      document.activeElement && document.activeElement.blur && document.activeElement.blur();
     },
 
     _createFocusBackfillItem: function() {
@@ -1779,7 +1784,7 @@ will only render 20.
       var focusedModel = this.modelForElement(this._focusedItem);
       var hasOffscreenFocusedItem = this._offscreenFocusedItem !== null;
       var fidx = this._focusedVirtualIndex;
-      if (!targetModel || !focusedModel) {
+      if (!targetModel) {
         return;
       }
       if (focusedModel === targetModel) {
@@ -1790,7 +1795,9 @@ will only render 20.
       } else {
         this._restoreFocusedItem();
         // Restore tabIndex for the currently focused item.
-        focusedModel.tabIndex = -1;
+        if (focusedModel) {
+          focusedModel.tabIndex = -1;
+        }
         // Set the tabIndex for the next focused item.
         targetModel.tabIndex = 0;
         fidx = targetModel[this.indexAs];

--- a/test/fixtures/helpers.html
+++ b/test/fixtures/helpers.html
@@ -110,7 +110,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     var listRect = list.getBoundingClientRect();
     var x = listRect.left + (listRect.width / 2);
     var y = listRect.top + (n * itemHeight) + (itemHeight / 2);
-    return document.elementFromPoint(x, y);
+    return deepElementFromPoint(x, y);
   }
 
   function getLastItemFromList(list) {

--- a/test/focus.html
+++ b/test/focus.html
@@ -92,6 +92,41 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       });
     });
 
+    test('blur when focused item is removed', function(done) {
+      list.items = buildDataSet(100);
+
+      flush(function() {
+        getFirstItemFromList(list).focus();
+
+        assert.notEqual(document.activeElement, document.body);
+
+        list.splice('items', 0, 1);
+
+        // HACK(keanulee): This test fails in IE11 if the window is not focused, so
+        // skip this test in that case.
+        if (document.hasFocus()) {
+          assert.equal(document.activeElement, document.body);
+        }
+        done();
+      });
+    });
+
+    test('focusItem()', function(done) {
+      list.items = buildDataSet(100);
+
+      flush(function() {
+        var i = 1;
+        var item = getNthItemFromList(list, i);
+
+        assert.equal(item.tabIndex, -1);
+
+        list.focusItem(i);
+
+        assert.equal(item.tabIndex, 0);
+        done();
+      });
+    });
+
     test('should not hide the list', function(done) {
       container.useTabIndex = true;
       list.items = buildDataSet(100);

--- a/test/smoke/remove.html
+++ b/test/smoke/remove.html
@@ -1,0 +1,84 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+
+<!doctype html>
+<html id="html">
+<head>
+
+  <title>iron-list demo</title>
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=no">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+
+  <script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <link rel="import" href="../../../polymer/polymer.html">
+  <link rel="import" href="../../iron-list.html">
+
+</head>
+<body unresolved>
+  
+  <dom-module id="x-demo">
+    <template>
+      <style>
+        iron-list {
+          height: 300px;
+        }
+        
+        a:focus {
+          color: red;
+        }
+      </style>
+
+      <iron-list id="list" items="[[items]]">
+        <template>
+          <div tabindex$="[[tabIndex]]">
+            <span>[[item.name]]</span>
+            <input type="text">
+            <a href="#" on-click="_removeItem">Remove</a>
+          </div>
+        </template>
+      </iron-list>
+    </template>
+
+    <script>
+    HTMLImports.whenReady(function() {
+      Polymer({
+        is: 'x-demo',
+        
+        attached() {
+          var items = [];
+          for (var i = 0; i < 1000; ++i) {
+            items.push({
+              name: 'a'+i,
+              modelIndex: i
+            });
+          }
+          this.items = items;
+        },
+        
+        _removeItem(e) {
+          e.preventDefault();
+
+          var i = this.$.list.modelForElement(e.target.parentElement).index;
+          this.splice('items', i, 1);
+          this.async(_ => this.$.list.focusItem(i));
+        }
+      });
+    });
+    </script>
+  </dom-module>
+
+  <x-demo></x-demo>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes #336, closes #427 

Removes focus if the focused item in the list is removed. Also adds a `focusItem()` method which may be used to control focus after the item is removed (see test/smoke/remove.html).