### PR TITLE
Update `lastVisibleIndex` and `firstVisibleIndex` when list is resized.

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -817,6 +817,10 @@ will only render 20.
           parseInt(styles['padding-top'], 10);
       this._isRTL = Boolean(styles.direction === 'rtl');
       this._viewportWidth = this.$.items.offsetWidth;
+      var viewportHeight = this._scrollTargetHeight;
+      if (viewportHeight !== this._viewportHeight) {
+        this._resetScrollPosition(this.scrollTarget.scrollTop);
+      }
       this._viewportHeight = this._scrollTargetHeight;
       this.grid && this._updateGridMetrics();
     },
@@ -1426,7 +1430,6 @@ will only render 20.
       this._updateScrollerSize(true);
       this._positionItems();
       this._resetScrollPosition(this._physicalTop + this._scrollOffset + targetOffsetTop);
-
       this._increasePoolIfNeeded(0);
       // clear cached visible index.
       this._firstVisibleIndexVal = null;

--- a/iron-list.html
+++ b/iron-list.html
@@ -1449,10 +1449,10 @@ will only render 20.
      * when the element is resized.
      */
     _resizeHandler: function() {
-      // clear cached visible index.
-      this._firstVisibleIndexVal = null;
-      this._lastVisibleIndexVal = null;
       this._debounceRender(function() {
+        // clear cached visible index.
+        this._firstVisibleIndexVal = null;
+        this._lastVisibleIndexVal = null;
         // Skip the resize event on touch devices when the address bar slides up.
         var delta = Math.abs(this._viewportHeight - this._scrollTargetHeight);
         this.updateViewportBoundaries();

--- a/iron-list.html
+++ b/iron-list.html
@@ -1426,6 +1426,7 @@ will only render 20.
       this._updateScrollerSize(true);
       this._positionItems();
       this._resetScrollPosition(this._physicalTop + this._scrollOffset + targetOffsetTop);
+
       this._increasePoolIfNeeded(0);
       // clear cached visible index.
       this._firstVisibleIndexVal = null;
@@ -1445,6 +1446,9 @@ will only render 20.
      * when the element is resized.
      */
     _resizeHandler: function() {
+      // clear cached visible index.
+      this._firstVisibleIndexVal = null;
+      this._lastVisibleIndexVal = null;
       this._debounceRender(function() {
         // Skip the resize event on touch devices when the address bar slides up.
         var delta = Math.abs(this._viewportHeight - this._scrollTargetHeight);

--- a/iron-list.html
+++ b/iron-list.html
@@ -817,10 +817,6 @@ will only render 20.
           parseInt(styles['padding-top'], 10);
       this._isRTL = Boolean(styles.direction === 'rtl');
       this._viewportWidth = this.$.items.offsetWidth;
-      var viewportHeight = this._scrollTargetHeight;
-      if (viewportHeight !== this._viewportHeight) {
-        this._resetScrollPosition(this.scrollTarget.scrollTop);
-      }
       this._viewportHeight = this._scrollTargetHeight;
       this.grid && this._updateGridMetrics();
     },

--- a/test/fixtures/x-list.html
+++ b/test/fixtures/x-list.html
@@ -21,6 +21,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       .item {
         color: white;
+        overflow: hidden;
       }
 
       .item:nth-child(odd) {

--- a/test/grid.html
+++ b/test/grid.html
@@ -247,7 +247,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         list.items = buildDataSet(64);
         Polymer.dom.flush();
         assert.equal(list.lastVisibleIndex, 8, 'The 50th item should be visible.');
-        list.style.height = '400px'
+        list.style.height = '400px';
         list.fire('iron-resize');
         PolymerFlush();
         assert.equal(list.lastVisibleIndex, 11, 'The last visible changed as expected.')
@@ -264,7 +264,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           setTimeout(function() {
             assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
             assert.equal(list.firstVisibleIndex, 57, 'The first visible index is appropriately set.');
-            list.style.height = '400px'
+            list.style.height = '400px';
             list.fire('iron-resize');
             PolymerFlush();
             assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');

--- a/test/grid.html
+++ b/test/grid.html
@@ -278,13 +278,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(list.firstVisibleIndex, 57, 'The first visible index is appropriately set.');
             list.style.height = '400px';
             requestAnimationFrame(function() {
-              setTimeout(function() {
-                PolymerFlush();
-                list.fire('iron-resize');
-                PolymerFlush();
-                assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
-                assert.equal(list.firstVisibleIndex, 54, 'The first visible item changed as expected.')
-                done();
+              requestAnimationFrame(function() {
+                setTimeout(function() {
+                  PolymerFlush();
+                  list.fire('iron-resize');
+                  PolymerFlush();
+                  assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
+                  assert.equal(list.firstVisibleIndex, 54, 'The first visible item changed as expected.')
+                  done();
+                });
               });
             });
           });

--- a/test/grid.html
+++ b/test/grid.html
@@ -241,7 +241,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
     });
- 
+
+    test('last visible items should change on resize', function(done) {
+      flush(function() {
+        list.items = buildDataSet(64);
+        Polymer.dom.flush();
+        assert.equal(list.lastVisibleIndex, 8, 'The 50th item should be visible.');
+        list.style.height = '400px'
+        list.fire('iron-resize');
+        PolymerFlush();
+        assert.equal(list.lastVisibleIndex, 11, 'The last visible changed as expected.')
+        done();
+      });
+    });
+
+    test('first visible items should change on resize when scrolled to the end of the list', function(done) {
+      flush(function() {
+        list.items = buildDataSet(64);
+        Polymer.dom.flush();
+        list.scroll(0, 10000000);
+        requestAnimationFrame(function() {
+          setTimeout(function() {
+            assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
+            assert.equal(list.firstVisibleIndex, 57, 'The first visible index is appropriately set.');
+            list.style.height = '400px'
+            list.fire('iron-resize');
+            PolymerFlush();
+            assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
+            assert.equal(list.firstVisibleIndex, 54, 'The first visible item changed as expected.')
+            done();
+          });
+        });
+      });
+    });
+
   });
 </script>
 

--- a/test/grid.html
+++ b/test/grid.html
@@ -248,10 +248,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         Polymer.dom.flush();
         assert.equal(list.lastVisibleIndex, 8, 'The 50th item should be visible.');
         list.style.height = '400px';
-        list.fire('iron-resize');
-        PolymerFlush();
-        assert.equal(list.lastVisibleIndex, 11, 'The last visible changed as expected.')
-        done();
+        requestAnimationFrame(function() {
+          requestAnimationFrame(function() {
+            list.fire('iron-resize');
+            PolymerFlush();
+            assert.equal(list.lastVisibleIndex, 11, 'The last visible changed as expected.')
+            done();
+          });
+        });
       });
     });
 
@@ -265,11 +269,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
             assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
             assert.equal(list.firstVisibleIndex, 57, 'The first visible index is appropriately set.');
             list.style.height = '400px';
-            list.fire('iron-resize');
-            PolymerFlush();
-            assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
-            assert.equal(list.firstVisibleIndex, 54, 'The first visible item changed as expected.')
-            done();
+            requestAnimationFrame(function() {
+              requestAnimationFrame(function() {
+                list.fire('iron-resize');
+                PolymerFlush();
+                assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
+                assert.equal(list.firstVisibleIndex, 54, 'The first visible item changed as expected.')
+                done();
+              });
+            });
           });
         });
       });

--- a/test/grid.html
+++ b/test/grid.html
@@ -249,7 +249,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(list.lastVisibleIndex, 8, 'The 50th item should be visible.');
         list.style.height = '400px';
         requestAnimationFrame(function() {
-          requestAnimationFrame(function() {
+          setTimeout(function() {
+            PolymerFlush();
             list.fire('iron-resize');
             PolymerFlush();
             assert.equal(list.lastVisibleIndex, 11, 'The last visible changed as expected.')
@@ -266,11 +267,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         list.scroll(0, 10000000);
         requestAnimationFrame(function() {
           setTimeout(function() {
+            PolymerFlush();
             assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');
             assert.equal(list.firstVisibleIndex, 57, 'The first visible index is appropriately set.');
             list.style.height = '400px';
             requestAnimationFrame(function() {
-              requestAnimationFrame(function() {
+              setTimeout(function() {
+                PolymerFlush();
                 list.fire('iron-resize');
                 PolymerFlush();
                 assert.equal(list.lastVisibleIndex, 64, 'Scroll is maxed out.');

--- a/test/grid.html
+++ b/test/grid.html
@@ -244,9 +244,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('last visible items should change on resize', function(done) {
       flush(function() {
+        // Physical scroll bar causes there to be less columns than expected.
+        // Force list to be wide enough to allow for 3 columns and the scroller.
+        list.style.width = '320px';
         list.items = buildDataSet(64);
         Polymer.dom.flush();
-        assert.equal(list.lastVisibleIndex, 8, 'The 50th item should be visible.');
+        assert.equal(list.lastVisibleIndex, 8, 'The 8th item should be visible.');
         list.style.height = '400px';
         requestAnimationFrame(function() {
           setTimeout(function() {
@@ -262,6 +265,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     test('first visible items should change on resize when scrolled to the end of the list', function(done) {
       flush(function() {
+        // Physical scroll bar causes there to be less columns than expected.
+        // Force list to be wide enough to allow for 3 columns and the scroller.
+        list.style.width = '320px';
         list.items = buildDataSet(64);
         Polymer.dom.flush();
         list.scroll(0, 10000000);

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -102,10 +102,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           PolymerFlush();
           assert.equal(list.lastVisibleIndex, 49, 'The 50th item should be visible.');
           container.listHeight = 300;
-          list.fire('iron-resize');
-          PolymerFlush();
-          assert.equal(list.lastVisibleIndex, 74, 'The last visible changed as expected.')
-          done();
+          requestAnimationFrame(function() {
+            list.fire('iron-resize');
+            PolymerFlush();
+            assert.equal(list.lastVisibleIndex, 74, 'The last visible changed as expected.')
+            done();
+          });
         });
       });
 
@@ -118,11 +120,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
           assert.equal(list.firstVisibleIndex, 150, 'The first visible index is appropriately set.');
           container.listHeight = 300;
-          list.fire('iron-resize');
-          PolymerFlush();
-          assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
-          assert.equal(list.firstVisibleIndex, 125, 'The first visible item changed as expected.')
-          done();
+          requestAnimationFrame(function() {
+            list.fire('iron-resize');
+            PolymerFlush();
+            assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
+            assert.equal(list.firstVisibleIndex, 125, 'The first visible item changed as expected.')
+            done();
+          });
         });
       });
     });

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -121,11 +121,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           assert.equal(list.firstVisibleIndex, 150, 'The first visible index is appropriately set.');
           container.listHeight = 300;
           requestAnimationFrame(function() {
-            list.fire('iron-resize');
-            PolymerFlush();
-            assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
-            assert.equal(list.firstVisibleIndex, 125, 'The first visible item changed as expected.')
-            done();
+            requestAnimationFrame(function() {
+              PolymerFlush();
+              list.fire('iron-resize');
+              PolymerFlush();
+              assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
+              assert.equal(list.firstVisibleIndex, 125, 'The first visible item changed as expected.')
+              done();
+            });
           });
         });
       });

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -94,6 +94,37 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       });
+
+      test('last visible items should change on resize', function(done) {
+        flush(function() {
+          list.style.display = '';
+          list.fire('iron-resize');
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 49, 'The 50th item should be visible.');
+          container.listHeight = 300;
+          list.fire('iron-resize');
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 74, 'The last visible changed as expected.')
+          done();
+        });
+      });
+
+      test('first visible items should change on resize when scrolled to the end of the list', function(done) {
+        flush(function() {
+          list.style.display = '';
+          list.fire('iron-resize');
+          list.scrollToIndex(199);
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
+          assert.equal(list.firstVisibleIndex, 150, 'The first visible index is appropriately set.');
+          container.listHeight = 300;
+          list.fire('iron-resize');
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 199, 'Scroll is maxed out.');
+          assert.equal(list.firstVisibleIndex, 125, 'The first visible item changed as expected.')
+          done();
+        });
+      });
     });
 
   </script>


### PR DESCRIPTION
Fixes #451 

`lastVisibleIndex` and `firstVisibleIndex` are both read or set variables, so they need to be nulled out in `_resizeHandler` when the list is resized or they will persist stale data until the list is scrolled or `items` are changed, which do the same.