### PR TITLE
Update layout correctly when changing the value of `grid`

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1459,10 +1459,10 @@ will only render 20.
      * when the element is resized.
      */
     _resizeHandler: function() {
-      // clear cached visible index.
-      this._firstVisibleIndexVal = null;
-      this._lastVisibleIndexVal = null;
       this._debounceRender(function() {
+        // clear cached visible index.
+        this._firstVisibleIndexVal = null;
+        this._lastVisibleIndexVal = null;
         // Skip the resize event on touch devices when the address bar slides up.
         var delta = Math.abs(this._viewportHeight - this._scrollTargetHeight);
         this.updateViewportBoundaries();

--- a/iron-list.html
+++ b/iron-list.html
@@ -420,7 +420,8 @@ will only render 20.
       '_itemsChanged(items.*)',
       '_selectionEnabledChanged(selectionEnabled)',
       '_multiSelectionChanged(multiSelection)',
-      '_setOverflow(scrollTarget, scrollOffset)'
+      '_setOverflow(scrollTarget, scrollOffset)',
+      '_gridChanged(grid)'
     ],
 
     behaviors: [
@@ -1056,6 +1057,10 @@ will only render 20.
       instanceProps.tabIndex = true;
       this._instanceProps = instanceProps;
       this.templatize(this._userTemplate, this.mutableData);
+    },
+
+    _gridChanged: function() {
+      this.fire('iron-resize');
     },
 
     /**

--- a/iron-list.html
+++ b/iron-list.html
@@ -1063,7 +1063,8 @@ will only render 20.
       this.templatize(this._userTemplate, this.mutableData);
     },
 
-    _gridChanged: function() {
+    _gridChanged: function(newGrid, oldGrid) {
+      if (typeof oldGrid === 'undefined') return;
       this.fire('iron-resize');
       Polymer.flush ? Polymer.flush() : Polymer.dom.flush();
       this._updateGridMetrics();

--- a/iron-list.html
+++ b/iron-list.html
@@ -1065,7 +1065,7 @@ will only render 20.
 
     _gridChanged: function(newGrid, oldGrid) {
       if (typeof oldGrid === 'undefined') return;
-      this.fire('iron-resize');
+      this.notifyResize();
       Polymer.flush ? Polymer.flush() : Polymer.dom.flush();
       this._updateGridMetrics();
     },

--- a/iron-list.html
+++ b/iron-list.html
@@ -1061,6 +1061,8 @@ will only render 20.
 
     _gridChanged: function() {
       this.fire('iron-resize');
+      Polymer.flush ? Polymer.flush() : Polymer.dom.flush();
+      this._updateGridMetrics();
     },
 
     /**
@@ -1262,7 +1264,9 @@ will only render 20.
         this._updateGridMetrics();
         this._physicalSize = Math.ceil(this._physicalCount / this._itemsPerRow) * this._rowHeight;
       } else {
+        oldPhysicalSize = (this._itemsPerRow === 1) ? oldPhysicalSize :  Math.ceil(this._physicalCount / this._itemsPerRow) * this._rowHeight;
         this._physicalSize = this._physicalSize + newPhysicalSize - oldPhysicalSize;
+        this._itemsPerRow = 1;
       }
       // Update the average if it measured something.
       if (this._physicalAverageCount !== prevAvgCount) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -359,7 +359,8 @@ will only render 20.
       grid: {
         type: Boolean,
         value: false,
-        reflectToAttribute: true
+        reflectToAttribute: true,
+        observer: '_gridChanged'
       },
 
       /**
@@ -420,8 +421,7 @@ will only render 20.
       '_itemsChanged(items.*)',
       '_selectionEnabledChanged(selectionEnabled)',
       '_multiSelectionChanged(multiSelection)',
-      '_setOverflow(scrollTarget, scrollOffset)',
-      '_gridChanged(grid)'
+      '_setOverflow(scrollTarget, scrollOffset)'
     ],
 
     behaviors: [

--- a/test/grid-changed.html
+++ b/test/grid-changed.html
@@ -43,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       list = container.list;
     });
 
-    test('check from grid=true to grid=false and back', function(done) {
+    test('check from grid=true to grid=false and back', function() {
       // Physical scroll bar causes there to be less columns than expected.
       // Force list to be wide enough to allow for 3 columns and the scroller.
       list.style.width = '320px';
@@ -52,21 +52,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(list.lastVisibleIndex, 8);
       assert.equal(list._scrollHeight, 3400);
       list.grid = false;
-      requestAnimationFrame(function() {
-        PolymerFlush();
-        assert.equal(list.lastVisibleIndex, 2);
-        assert.equal(list._scrollHeight, 10000);
-        list.grid = true;
-        requestAnimationFrame(function() {
-          PolymerFlush();
-          assert.equal(list.lastVisibleIndex, 8);
-          assert.equal(list._scrollHeight, 3400);
-          done();
-        });
-      });
+      PolymerFlush();
+      assert.equal(list.lastVisibleIndex, 2);
+      assert.equal(list._scrollHeight, 10000);
+      list.grid = true;
+      PolymerFlush();
+      assert.equal(list.lastVisibleIndex, 8);
+      assert.equal(list._scrollHeight, 3400);
     });
 
-    test('check from grid=false to grid=true and back', function(done) {
+    test('check from grid=false to grid=true and back', function() {
       // Physical scroll bar causes there to be less columns than expected.
       // Force list to be wide enough to allow for 3 columns and the scroller.
       list.style.width = '320px';
@@ -77,18 +72,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       assert.equal(list._scrollHeight, 10000);
       list.grid = true;
       PolymerFlush();
-      requestAnimationFrame(function() {
-        PolymerFlush();
-        assert.equal(list.lastVisibleIndex, 8, 'Grid should show more items.');
-        assert.equal(list._scrollHeight, 3400);
-        list.grid = false;
-        requestAnimationFrame(function() {
-          PolymerFlush();
-          assert.equal(list.lastVisibleIndex, 2);
-          assert.equal(list._scrollHeight, 10000);
-          done();
-        });
-      });
+      assert.equal(list.lastVisibleIndex, 8, 'Grid should show more items.');
+      assert.equal(list._scrollHeight, 3400);
+      list.grid = false;
+      PolymerFlush();
+      assert.equal(list.lastVisibleIndex, 2);
+      assert.equal(list._scrollHeight, 10000);
     });
 
   });

--- a/test/grid-changed.html
+++ b/test/grid-changed.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-list test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+  <link rel="import" href="fixtures/helpers.html">
+  <link rel="import" href="fixtures/x-grid.html">
+
+</head>
+<body>
+  <!-- Issue: web-component-tester/issues/505 -->
+  <script>void(0)</script>
+
+  <test-fixture id="trivialList">
+    <template>
+      <x-grid></x-grid>
+    </template>
+  </test-fixture>
+
+<script>
+
+  suite('basic features', function() {
+    var list, container;
+
+    setup(function() {
+      container = fixture('trivialList');
+      list = container.list;
+    });
+
+    test('check from grid=true to grid=false and back', function(done) {
+      // Physical scroll bar causes there to be less columns than expected.
+      // Force list to be wide enough to allow for 3 columns and the scroller.
+      list.style.width = '320px';
+      container.data = buildDataSet(100);
+      PolymerFlush();
+      assert.equal(list.lastVisibleIndex, 8);
+      assert.equal(list._scrollHeight, 3400);
+      list.grid = false;
+      requestAnimationFrame(function() {
+        PolymerFlush();
+        assert.equal(list.lastVisibleIndex, 2);
+        assert.equal(list._scrollHeight, 10000);
+        list.grid = true;
+        requestAnimationFrame(function() {
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 8);
+          assert.equal(list._scrollHeight, 3400);
+          done();
+        });
+      });
+    });
+
+    test('check from grid=false to grid=true and back', function(done) {
+      // Physical scroll bar causes there to be less columns than expected.
+      // Force list to be wide enough to allow for 3 columns and the scroller.
+      list.style.width = '320px';
+      list.grid = false;
+      container.data = buildDataSet(100);
+      PolymerFlush();
+      assert.equal(list.lastVisibleIndex, 2);
+      assert.equal(list._scrollHeight, 10000);
+      list.grid = true;
+      PolymerFlush();
+      requestAnimationFrame(function() {
+        PolymerFlush();
+        assert.equal(list.lastVisibleIndex, 8, 'Grid should show more items.');
+        assert.equal(list._scrollHeight, 3400);
+        list.grid = false;
+        requestAnimationFrame(function() {
+          PolymerFlush();
+          assert.equal(list.lastVisibleIndex, 2);
+          assert.equal(list._scrollHeight, 10000);
+          done();
+        });
+      });
+    });
+
+  });
+</script>
+
+</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -29,6 +29,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'different-heights.html?dom=shadow',
       'grid.html?dom=shadow',
       'grid-rtl.html?dom=shadow',
+      'grid-changed.html?dom=shadow',
       'bindings-host-to-item.html?dom=shadow',
       'template-overload.html?dom=shadow',
       'scroll-offset.html?dom=shadow',
@@ -43,6 +44,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'different-heights.html?wc-shadydom=true&wc-ce=true',
       'grid.html?wc-shadydom=true&wc-ce=true',
       'grid-rtl.html?wc-shadydom=true&wc-ce=true',
+      'grid-changed.html?wc-shadydom=true&wc-ce=true',
       'bindings-host-to-item.html?wc-shadydom=true&wc-ce=true',
       'template-overload.html?wc-shadydom=true&wc-ce=true',
       'scroll-offset.html?wc-shadydom=true&wc-ce=true'


### PR DESCRIPTION
Depends on #452 
Fixes #453 

When grid is changed a number of internal metrics need to be updated and the layout needs to be recast so that the list displays as expected.