### PR TITLE
Make sure that physical items are always managed as complete rows.

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -976,7 +976,7 @@ will only render 20.
           DEFAULT_PHYSICAL_COUNT, this._virtualCount - this._virtualStart);
       nextPhysicalCount = this._convertIndexToCompleteRow(nextPhysicalCount);
       var correction = nextPhysicalCount % this._itemsPerRow;
-      if (correction && nextPhysicalCount - correction <= this._physicalCount) {
+      if (correction && nextPhysicalCount - correction < this._physicalCount) {
         nextPhysicalCount += this._itemsPerRow;
       }
       nextPhysicalCount -= correction;

--- a/iron-list.html
+++ b/iron-list.html
@@ -975,11 +975,13 @@ will only render 20.
       var nextPhysicalCount = this._clamp(this._physicalCount + count,
           DEFAULT_PHYSICAL_COUNT, this._virtualCount - this._virtualStart);
       nextPhysicalCount = this._convertIndexToCompleteRow(nextPhysicalCount);
-      var correction = nextPhysicalCount % this._itemsPerRow;
-      if (correction && nextPhysicalCount - correction <= this._physicalCount) {
-        nextPhysicalCount += this._itemsPerRow;
+      if (this.grid) {
+        var correction = nextPhysicalCount % this._itemsPerRow;
+        if (correction && nextPhysicalCount - correction <= this._physicalCount) {
+          nextPhysicalCount += this._itemsPerRow;
+        }
+        nextPhysicalCount -= correction;
       }
-      nextPhysicalCount -= correction;
       var delta = nextPhysicalCount - this._physicalCount;
       var nextIncrease = Math.round(this._physicalCount * 0.5);
 
@@ -1684,7 +1686,7 @@ will only render 20.
     _convertIndexToCompleteRow: function(idx) {
       // when grid == false _itemPerRow can be unset.
       this._itemsPerRow = this._itemsPerRow || 1;
-      return Math.ceil(idx / this._itemsPerRow) * this._itemsPerRow;
+      return this.grid ? Math.ceil(idx / this._itemsPerRow) * this._itemsPerRow : idx;
     },
 
     _isIndexRendered: function(idx) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -976,7 +976,7 @@ will only render 20.
           DEFAULT_PHYSICAL_COUNT, this._virtualCount - this._virtualStart);
       nextPhysicalCount = this._convertIndexToCompleteRow(nextPhysicalCount);
       var correction = nextPhysicalCount % this._itemsPerRow;
-      if (correction && nextPhysicalCount - correction < this._physicalCount) {
+      if (correction && nextPhysicalCount - correction <= this._physicalCount) {
         nextPhysicalCount += this._itemsPerRow;
       }
       nextPhysicalCount -= correction;
@@ -1004,7 +1004,9 @@ will only render 20.
         this._templateCost = (window.performance.now() - ts) / delta;
         nextIncrease = Math.round(this._physicalCount * 0.5);
       }
-      if (this._virtualEnd === this._virtualCount - 1 || nextIncrease === 0) {
+      // The upper bounds is not fixed when dealing with a grid that doesn't
+      // fill it's last row with the exact number of items per row.
+      if (this._virtualEnd >= this._virtualCount - 1 || nextIncrease === 0) {
         // Do nothing.
       } else if (!this._isClientFull()) {
         this._debounceRender(

--- a/iron-list.html
+++ b/iron-list.html
@@ -629,7 +629,8 @@ will only render 20.
      * The largest n-th value for an item such that it can be rendered in `_physicalStart`.
      */
     get _maxVirtualStart() {
-      return Math.max(0, this._virtualCount - this._physicalCount);
+      var virtualCount = this._convertIndexToCompleteRow(this._virtualCount);
+      return Math.max(0, virtualCount - this._physicalCount);
     },
 
     set _virtualStart(val) {
@@ -973,6 +974,12 @@ will only render 20.
     _increasePoolIfNeeded: function(count) {
       var nextPhysicalCount = this._clamp(this._physicalCount + count,
           DEFAULT_PHYSICAL_COUNT, this._virtualCount - this._virtualStart);
+      nextPhysicalCount = this._convertIndexToCompleteRow(nextPhysicalCount);
+      var correction = nextPhysicalCount % this._itemsPerRow;
+      if (correction && nextPhysicalCount - correction <= this._physicalCount) {
+        nextPhysicalCount += this._itemsPerRow;
+      }
+      nextPhysicalCount -= correction;
       var delta = nextPhysicalCount - this._physicalCount;
       var nextIncrease = Math.round(this._physicalCount * 0.5);
 
@@ -1666,6 +1673,16 @@ will only render 20.
         this._focusedVirtualIndex = this._virtualStart;
         this._focusedItem = this._physicalItems[this._physicalStart];
       }
+    },
+
+    /**
+     * Converts a random index to the index of the item that completes it's row.
+     * Allows for better order and fill computation when grid == true.
+     */
+    _convertIndexToCompleteRow: function(idx) {
+      // when grid == false _itemPerRow can be unset.
+      this._itemsPerRow = this._itemsPerRow || 1;
+      return Math.ceil(idx / this._itemsPerRow) * this._itemsPerRow;
     },
 
     _isIndexRendered: function(idx) {

--- a/test/grid.html
+++ b/test/grid.html
@@ -241,7 +241,33 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
     });
- 
+
+    test('Items display in the correct column after scroll', function(done) {
+      list.style.width = '500px';
+      list.style.height = '500px';
+      list.fire('iron-resize');
+      container.data = buildDataSet(5000);
+      PolymerFlush();
+
+      var setSize = list.items.length;
+      var rowHeight = container.itemSize;
+      var viewportHeight = list.offsetHeight;
+      var scrollToItem = 100;
+
+      function afterScroll() {
+        var firstItem = getNthItemFromGrid(list, 0);
+        assert.equal(firstItem.innerText, '100');
+        done();
+      }
+
+      simulateScroll({
+        list: list,
+        contribution: rowHeight,
+        target: getGridRowFromIndex(list, scrollToItem)*rowHeight,
+        onScrollEnd: afterScroll
+      });
+    });
+
   });
 </script>
 


### PR DESCRIPTION
Fixes #446

When grid items are represented by physical items that don't add up to complete rows it is possible for the recycler to skip items causing them to not be shown and other items to be positioned in the wrong column.