### PR TITLE
Select items

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1541,7 +1541,7 @@ will only render 20.
       if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
         items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
       }
-      if (!indexes.length) {
+      if (typeof indexes === 'undefined' || !indexes.length) {
         items = this.items;
       } else {
         item = indexes.map(function(idx) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1531,6 +1531,7 @@ will only render 20.
 
     // TODO: finish me!!
     selectIndexesV1: function(indexes) {
+      var items = [];
       var item = {};
       var model = {};
       var skey = '';
@@ -1540,10 +1541,13 @@ will only render 20.
       if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
         items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
       }
-      items = items || this.items;
-      items = items.map(function(item) {
-        return this._getNormalizedItem(item);
-      }.bind(this));
+      if (!indexes.length) {
+        items = this.items;
+      } else {
+        item = indexes.map(function(idx) {
+          return this.items[idx];
+        }.bind(this));
+      }
       this.$.selector.set('selected', items);
       items = items.filter(function(item) {
         return !(this.$.selector).isSelected(item);

--- a/iron-list.html
+++ b/iron-list.html
@@ -1563,21 +1563,47 @@ will only render 20.
     },
 
     selectIndexesV2: function(indexes) {
-        this.$.selector.__selectedMap.clear();
-        var items = indexes.map(function(idx) {
-          var item = this.items[idx];
-          if (this._isIndexRendered(idx)) {
-            var model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(idx)]);
+        this.selectedItems.map(function(item){
+          var index = this.items.indexOf(item);
+          if (this._isIndexRendered(index)) {
+            var model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(index)]);
+            model[this.selectedAs] = false;
+            this.updateSizeForIndex(index);
+          }
+        }.bind(this));
+        indexes.forEach(function(index) {
+          if (this._isIndexRendered(index)) {
+            var model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(index)]);
             if (model) {
               model[this.selectedAs] = true;
             }
-            this.updateSizeForIndex(idx);
+            this.updateSizeForIndex(index);
           }
-          this.$.selector.__selectedMap.set(item, idx);
-          return item;
         }.bind(this));
-        this.$.selector.__updateLinks();
-        this.$.selector.set('selected', items);
+        this.$.selector.selectIndexes(indexes);
+    },
+
+    selectAll: function() {
+      if (this.$.selector.selectIndex) {
+        // v2
+        this.selectAllV2();
+      } else {
+        // v1
+        this.selectIndexes();
+      }
+    },
+
+    selectAllV2: function() {
+      this.items.forEach(function(item, index) {
+        if (this._isIndexRendered(index)) {
+          var model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(index)]);
+          if (model) {
+            model[this.selectedAs] = true;
+          }
+          this.updateSizeForIndex(index);
+        }
+      }.bind(this));
+      this.$.selector.selectAll();
     },
 
     /**

--- a/iron-list.html
+++ b/iron-list.html
@@ -1538,15 +1538,13 @@ will only render 20.
       var icol = Polymer.Collection.get((this.$.selector).items);
       var key = '';
       // Cast an arguments list that doesn't consist of a single array to an array
-      if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
-        items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
-      }
-      if (typeof indexes === 'undefined' || !indexes.length) {
-        items = this.items;
-      } else {
+      if (arguments.length > 1 || (typeof indexes !== 'undefined' && !Array.isArray(indexes))) {
+        indexes = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
         item = indexes.map(function(idx) {
           return this.items[idx];
         }.bind(this));
+      } else {
+        items = this.items;
       }
       this.$.selector.set('selected', items);
       items = items.filter(function(item) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1529,29 +1529,23 @@ will only render 20.
       }
     },
 
-    // TODO: finish me!!
     selectIndexesV1: function(indexes) {
       var items = [];
       var item = {};
       var index = -1;
       var model = {};
-      var skey = '';
-      var icol = Polymer.Collection.get((this.$.selector).items);
-      var key = '';
       // Cast an arguments list that doesn't consist of a single array to an array
       if (arguments.length > 1 || (typeof indexes !== 'undefined' && !Array.isArray(indexes))) {
         indexes = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
-        item = indexes.map(function(idx) {
+        items = indexes.map(function(idx) {
           return this.items[idx];
         }.bind(this));
       } else {
         items = this.items;
       }
-      this.$.selector.set('selected', items);
       items = items.filter(function(item) {
         return !(this.$.selector).isSelected(item);
       }.bind(this));
-      this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
       for (var i = 0, l = items.length; i < l; i++) {
         item = items[i];
         index = (indexes) ? indexes[i] : i;
@@ -1562,10 +1556,8 @@ will only render 20.
           }
           this.updateSizeForIndex(index);
         }
-        key = icol.getKey(item);
-        skey = (this.$.selector)._selectedColl.getKey(item);
-        (this.$.selector).linkPaths("selected." + skey, "items." + key);
       }
+      this.$.selector.selectItems(items);
     },
 
     selectIndexesV2: function(indexes) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1501,6 +1501,86 @@ will only render 20.
     },
 
     /**
+     * Select the array of list items provided or
+     * select the entire list.
+     *
+     * @method selectItems
+     * @param {array} items The array of item objects or indexes
+     */
+    selectItems: function(items) {
+      var indexes = [];
+      if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
+        items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
+      }
+      items = items || this.items;
+      indexes = items.map(function(item) {
+        return (typeof item === 'number') ? item : this.items.indexOf(item);
+      }.bind(this));
+      return this.selectIndexes(indexes);
+    },
+
+    selectIndexes: function(indexes) {
+      if (this.$.selector.selectIndex) {
+        // v2
+        this.selectIndexesV2(indexes);
+      } else {
+        // v1
+        this.selectIndexesV1(indexes);
+      }
+    },
+
+    // TODO: finish me!!
+    selectIndexesV1: function(indexes) {
+      var item = {};
+      var model = {};
+      var skey = '';
+      var icol = Polymer.Collection.get((this.$.selector).items);
+      var key = '';
+      // Cast an arguments list that doesn't consist of a single array to an array
+      if (arguments.length > 1 || (typeof items !== 'undefined' && !Array.isArray(items))) {
+        items = !!Array.from ? Array.from(arguments) : [].slice.call(arguments);
+      }
+      items = items || this.items;
+      items = items.map(function(item) {
+        return this._getNormalizedItem(item);
+      }.bind(this));
+      this.$.selector.set('selected', items);
+      items = items.filter(function(item) {
+        return !(this.$.selector).isSelected(item);
+      }.bind(this));
+      this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
+      for (var i = 0, l = items.length; i < l; i++) {
+        item = items[i];
+        model = this._getModelFromItem(item);
+        if (model) {
+          model[this.selectedAs] = true;
+        }
+        key = icol.getKey(item);
+        skey = (this.$.selector)._selectedColl.getKey(item);
+        (this.$.selector).linkPaths("selected." + skey, "items." + key);
+        this.updateSizeForItem(item);
+      }
+    },
+
+    selectIndexesV2: function(indexes) {
+        this.$.selector.__selectedMap.clear();
+        var items = indexes.map(function(idx) {
+          var item = this.items[idx];
+          if (this._isIndexRendered(idx)) {
+            var model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(idx)]);
+            if (model) {
+              model[this.selectedAs] = true;
+            }
+            this.updateSizeForIndex(idx);
+          }
+          this.$.selector.__selectedMap.set(item, idx);
+          return item;
+        }.bind(this));
+        this.$.selector.__updateLinks();
+        this.$.selector.set('selected', items);
+    },
+
+    /**
      * Deselects the given item.
      *
      * @method deselect

--- a/iron-list.html
+++ b/iron-list.html
@@ -1533,6 +1533,7 @@ will only render 20.
     selectIndexesV1: function(indexes) {
       var items = [];
       var item = {};
+      var index = -1;
       var model = {};
       var skey = '';
       var icol = Polymer.Collection.get((this.$.selector).items);
@@ -1553,14 +1554,17 @@ will only render 20.
       this.$.selector._selectedColl = Polymer.Collection.get((this.$.selector).selected);
       for (var i = 0, l = items.length; i < l; i++) {
         item = items[i];
-        model = this._getModelFromItem(item);
-        if (model) {
-          model[this.selectedAs] = true;
+        index = (indexes) ? indexes[i] : i;
+        if (this._isIndexRendered(index)) {
+          model = this.modelForElement(this._physicalItems[this._getPhysicalIndex(index)]);
+          if (model) {
+            model[this.selectedAs] = true;
+          }
+          this.updateSizeForIndex(index);
         }
         key = icol.getKey(item);
         skey = (this.$.selector)._selectedColl.getKey(item);
         (this.$.selector).linkPaths("selected." + skey, "items." + key);
-        this.updateSizeForItem(item);
       }
     },
 


### PR DESCRIPTION
Fixes #436 

Replies on:
Polymer/polymer#4699
Polymer/polymer#4705

Adds code paths and tests to support selecting all of the items in the list or batch selecting a subset of the list. Further the ideas introduces in #437, this relies on extensions to both Polymer 1.x and 2.x to empower `array-selector` with selectItems and selectAll functionality and forks the application of that code as needed in this _hybrid_ component.