### PR TITLE
Make iron-list.html ES5 compatible

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1882,7 +1882,7 @@ will only render 20.
       }
     },
 
-    _forwardProperty(inst, name, value) {
+    _forwardProperty: function(inst, name, value) {
       if (IS_V2) {
         inst._setPendingProperty(name, value);
       } else {


### PR DESCRIPTION
`iron-list.html` had 1 piece of code using a syntax introduced in ES2015, and thus not compatible with ES5. As not everyone consuming the hybrid elements has an ES2015 conversion pipeline setup, it would be great if elements could stick to ES5 syntax.

If this is not a goal, feel free to close this PR.