### PR TITLE
example css for :host has two display properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ layout means (e.g. the `flex` or `fit` classes).
 <template is="x-list">
   <style>
     :host {
-      display: block;
       height: 100vh;
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
no point in having `display: block` if `display: flex` is later in the same rule.