### PR TITLE
Param description wrong.

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1493,7 +1493,7 @@ will only render 20.
      * Selects the item at the given index in the items array.
      *
      * @method selectIndex
-     * @param {Object} index The item instance.
+     * @param {number} index The index of the item in the items array.
      */
     selectIndex: function(index) {
       if (index < 0 || index >= this._virtualCount) {


### PR DESCRIPTION
Looks like a copy/paste error. Index is just a number, not an object.
To correct, I copied the description from `deselectIndex()`.