### PR TITLE
Fixes distribution of item template via named slots (Fixes 479)

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -941,7 +941,12 @@ will only render 20.
         // TODO(blasten):
         // First element child is item; Safari doesn't support children[0]
         // on a doc fragment. Test this to see if it still matters.
-        physicalItems[i] = inst.root.querySelector('*');
+        var newItem = inst.root.querySelector('*');
+        var templateSlotAttribute = this._userTemplate.getAttribute('slot');
+        if (templateSlotAttribute) {
+          newItem.setAttribute('slot', templateSlotAttribute);
+        }
+        physicalItems[i] = newItem;
         this._itemsParent.appendChild(inst.root);
       }
       return physicalItems;

--- a/test/fixtures/o-named-list.html
+++ b/test/fixtures/o-named-list.html
@@ -1,0 +1,24 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../iron-list.html">
+
+<dom-module id="o-named-list">
+  <template>
+    <iron-list id="list" items="{{items}}">
+      <slot></slot>
+    </iron-list>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({ is: 'o-named-list' });
+</script>

--- a/test/fixtures/slot-container.html
+++ b/test/fixtures/slot-container.html
@@ -1,0 +1,25 @@
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="o-named-list.html">
+
+<dom-module id="slot-container">
+  <template>
+    <slot></slot>
+    <o-named-list items="{{items}}">
+      <slot name="test"></slot>
+    </o-named-list>
+  </template>
+</dom-module>
+
+<script>
+  Polymer({ is: 'slot-container' });
+</script>

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'grid-changed.html?dom=shadow',
       'bindings-host-to-item.html?dom=shadow',
       'template-overload.html?dom=shadow',
+      'named-slot.html?dom=shadow',
       'scroll-offset.html?dom=shadow',
       'basic.html?wc-shadydom=true&wc-ce=true',
       'events.html?wc-shadydom=true&wc-ce=true',
@@ -47,7 +48,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'grid-changed.html?wc-shadydom=true&wc-ce=true',
       'bindings-host-to-item.html?wc-shadydom=true&wc-ce=true',
       'template-overload.html?wc-shadydom=true&wc-ce=true',
-      'scroll-offset.html?wc-shadydom=true&wc-ce=true'
+      'named-slot.html?wc-shadydom=true&wc-ce=true',
+      'scroll-offset.html?wc-shadydom=true&wc-cez=true'
     ]);
   </script>
 </body>

--- a/test/named-slot.html
+++ b/test/named-slot.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>iron-list test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="fixtures/helpers.html">
+  <link rel="import" href="fixtures/slot-container.html">
+
+</head>
+<body>
+  <!-- Issue: web-component-tester/issues/505 -->
+  <script>void(0)</script>
+
+  <test-fixture id="namedSlotList">
+    <template>
+      <slot-container>
+        <template slot="test">
+          <div class="overloaded-template">[[item.index]]</div>
+        </template>
+      </slot-container>
+    </template>
+  </test-fixture>
+
+  <script>
+
+    suite('named slot test', function() {
+      var list;
+
+      setup(function() {
+        list = fixture('namedSlotList');
+      });
+
+      test('slots point to the correct places', function(done) {
+        list.items = buildDataSet(100);
+
+        flush(function() {
+          var oNamedList = list.shadowRoot.querySelector('o-named-list');
+          assert.isNotNull(oNamedList);
+          assert.isDefined(oNamedList);
+          var ironList = oNamedList.shadowRoot.querySelector('iron-list');
+          assert.isNotNull(ironList);
+          assert.isDefined(ironList);
+          // get the light dom slot from slot-container.html
+          var slot = ironList.children[0];
+          assert.isNotNull(slot);
+          assert.isDefined(slot);
+          assert.isDefined(slot.assignedNodes);
+          // get the assigned nodes from the slot-container.html slot
+          var assignedNodes = slot.assignedNodes();
+          // get the assigned nodes corresponding to 
+          // the template in named-slot.html
+          assignedNodes = assignedNodes[1].assignedNodes();
+          // 100 items plus the initial template
+          assert.equal(assignedNodes.length, 101);
+          done();
+        });
+      });
+
+      test('check physical item size', function(done) {
+        var setSize = 10;
+        list.items = buildDataSet(setSize);
+
+        flush(function() {
+          assert.equal(list.items.length, setSize);
+          done();
+        });
+      });
+
+      test('check item template', function(done) {
+        list.items = buildDataSet(1);
+
+        flush(function() {
+          assert.isNotNull(Polymer.dom(list).querySelector('.overloaded-template'));
+          done();
+        });
+      });
+
+      test('check count of physical items', function(done) {
+        var setSize = 1;
+        list.items = buildDataSet(setSize);
+
+        flush(function() {
+          assert.equal(Polymer.dom(list).querySelectorAll('*').length - 1, setSize);
+          done();
+        });
+      });
+    });
+
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR fixes #479 by having each stamped instance of an item template inherit the slot attribute on the template item. In the `_createPool` function, the template is stamped and each new instance is appended as children to the template's parent node. When the template reaches the `iron-list` element via named slots, this will result in an incorrect distribution of the new nodes, because `iron-list` will not be able to correctly identify its assigned nodes.

See #479 for reasoning behind this approach over modifying the behavior of `Polymer.Templatizer` and a work around until this lands.

The accompanying tests use two levels of `slot`ing to demonstrate this.