### PR TITLE
Ensure _physicalSizes contains numbers

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -976,7 +976,7 @@ will only render 20.
         var ts = window.performance.now();
         // Concat arrays in place.
         [].push.apply(this._physicalItems, this._createPool(delta));
-        [].push.apply(this._physicalSizes, new Array(delta));
+        [].push.apply(this._physicalSizes, new Array(delta).fill(0));
         this._physicalCount = this._physicalCount + delta;
         // Update the physical start if it needs to preserve the model of the focused item.
         // In this situation, the focused item is currently rendered and its model would
@@ -1254,7 +1254,7 @@ will only render 20.
       var prevPhysicalAvg = this._physicalAverage;
 
       this._iterateItems(function(pidx, vidx) {
-        oldPhysicalSize += this._physicalSizes[pidx] || 0;
+        oldPhysicalSize += this._physicalSizes[pidx];
         this._physicalSizes[pidx] = this._physicalItems[pidx].offsetHeight;
         newPhysicalSize += this._physicalSizes[pidx];
         this._physicalAverageCount += this._physicalSizes[pidx] ? 1 : 0;

--- a/iron-list.html
+++ b/iron-list.html
@@ -976,7 +976,10 @@ will only render 20.
         var ts = window.performance.now();
         // Concat arrays in place.
         [].push.apply(this._physicalItems, this._createPool(delta));
-        [].push.apply(this._physicalSizes, new Array(delta).fill(0));
+        // Push 0s into physicalSizes. Can't use Array.fill because IE11 doesn't support it.
+        for (var i = 0; i < delta; i++) {
+          this._physicalSizes.push(0);
+        }
         this._physicalCount = this._physicalCount + delta;
         // Update the physical start if it needs to preserve the model of the focused item.
         // In this situation, the focused item is currently rendered and its model would


### PR DESCRIPTION
I've experimented few race conditions where having `this._physicalSizes[i] === undefined` would end up making properties like `this._physicalTop = NaN`.

This PR aims to clear these cases by ensuring the array is always containing numbers, hence ~uses [Array.fill](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill)~ (lol, just read the browser support, was mislead by not seeing any red color in the table) fills the array with 0s when the pool is increased.

Not really sure how to reproduce the race condition, open to suggestions.