### PR TITLE
Update rendered items after items mutations

### DIFF
--- a/iron-list.html
+++ b/iron-list.html
@@ -1109,23 +1109,26 @@ will only render 20.
       if (dot === 0) {
         dot = path.length;
       }
-      var idx = IS_V2
+      var vidx = IS_V2
           ? parseInt(path.substring(0, dot), 10)
           // Extract `#` from `path`.
           : parseInt(path.substring(1, dot), 10);
       var offscreenItem = this._offscreenFocusedItem;
-      var isIndexRendered = this._isIndexRendered(idx);
+      var isIndexRendered = this._isIndexRendered(vidx);
       var inst;
+      var pidx;
 
-      // If rendered, convert virtual index to physical index.
       if (isIndexRendered) {
-        idx = this._getPhysicalIndex(idx);
-        inst = this.modelForElement(this._physicalItems[idx]);
+        pidx = this._getPhysicalIndex(vidx);
+        inst = this.modelForElement(this._physicalItems[pidx]);
       } else if (offscreenItem) {
         inst = this.modelForElement(offscreenItem);
       }
-      if (!inst || inst[this.indexAs] !== idx) {
-        return;
+      if (!inst || inst[this.indexAs] !== vidx) {
+        // NOTE: consider valid instance if it has correct __key__ (Polymer 1.x).
+        if (!inst || inst.__key__ !== '#' + vidx) {
+          return;
+        }
       }
       path = path.substring(dot);
       path = this.as + (path ? '.' + path : '');
@@ -1135,7 +1138,7 @@ will only render 20.
       inst._flushProperties && inst._flushProperties(true);
       // TODO(blasten): V1 doesn't do this and it's a bug
       if (isIndexRendered) {
-        this._updateMetrics([idx]);
+        this._updateMetrics([pidx]);
         this._positionItems();
         this._updateScrollerSize();
       }
@@ -1701,10 +1704,10 @@ will only render 20.
       return idx >= this.firstVisibleIndex && idx <= this.lastVisibleIndex;
     },
 
-    _getPhysicalIndex: function(idx) {
-      return IS_V2 
-        ? (this._physicalStart + (idx - this._virtualStart)) % this._physicalCount
-        : this._physicalIndexForKey['#' + idx];
+    _getPhysicalIndex: function(vidx) {
+      return IS_V2
+        ? (this._physicalStart + (vidx - this._virtualStart)) % this._physicalCount
+        : this._physicalIndexForKey['#' + vidx];
     },
 
     focusItem: function(idx) {

--- a/iron-list.html
+++ b/iron-list.html
@@ -1113,6 +1113,7 @@ will only render 20.
           ? parseInt(path.substring(0, dot), 10)
           // Extract `#` from `path`.
           : parseInt(path.substring(1, dot), 10);
+      idx = this._clamp(idx, 0, this._virtualCount-1);
       var offscreenItem = this._offscreenFocusedItem;
       var isIndexRendered = this._isIndexRendered(idx);
       var inst;

--- a/iron-list.html
+++ b/iron-list.html
@@ -1113,15 +1113,14 @@ will only render 20.
           ? parseInt(path.substring(0, dot), 10)
           // Extract `#` from `path`.
           : parseInt(path.substring(1, dot), 10);
-      idx = this._clamp(idx, 0, this._virtualCount-1);
       var offscreenItem = this._offscreenFocusedItem;
       var isIndexRendered = this._isIndexRendered(idx);
       var inst;
-      var pidx;
 
+      // If rendered, convert virtual index to physical index.
       if (isIndexRendered) {
-        pidx = this._getPhysicalIndex(idx);
-        inst = this.modelForElement(this._physicalItems[pidx]);
+        idx = this._getPhysicalIndex(idx);
+        inst = this.modelForElement(this._physicalItems[idx]);
       } else if (offscreenItem) {
         inst = this.modelForElement(offscreenItem);
       }
@@ -1136,7 +1135,7 @@ will only render 20.
       inst._flushProperties && inst._flushProperties(true);
       // TODO(blasten): V1 doesn't do this and it's a bug
       if (isIndexRendered) {
-        this._updateMetrics([pidx]);
+        this._updateMetrics([idx]);
         this._positionItems();
         this._updateScrollerSize();
       }
@@ -1703,7 +1702,9 @@ will only render 20.
     },
 
     _getPhysicalIndex: function(idx) {
-      return (this._physicalStart + (idx - this._virtualStart)) % this._physicalCount;
+      return IS_V2 
+        ? (this._physicalStart + (idx - this._virtualStart)) % this._physicalCount
+        : this._physicalIndexForKey['#' + idx];
     },
 
     focusItem: function(idx) {

--- a/test/basic.html
+++ b/test/basic.html
@@ -20,8 +20,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="fixtures/x-list.html">
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/bindings-host-to-item.html
+++ b/test/bindings-host-to-item.html
@@ -22,8 +22,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-    <!-- Issue: web-component-tester/issues/505 -->
-    <script>void(0)</script>
 
 <test-fixture id="listWithBindings">
     <template>

--- a/test/different-heights.html
+++ b/test/different-heights.html
@@ -25,8 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/dynamic-item-size.html
+++ b/test/dynamic-item-size.html
@@ -25,8 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/events.html
+++ b/test/events.html
@@ -23,8 +23,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-list.html">
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/focus.html
+++ b/test/focus.html
@@ -24,8 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/grid-changed.html
+++ b/test/grid-changed.html
@@ -24,8 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/grid-rtl.html
+++ b/test/grid-rtl.html
@@ -22,8 +22,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="fixtures/x-grid.html">
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/grid.html
+++ b/test/grid.html
@@ -24,8 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/hidden-list.html
+++ b/test/hidden-list.html
@@ -24,8 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -25,8 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -324,15 +324,21 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(getFirstItemFromList(list).textContent, 'correct');
       });
 
-      test('Issue #492: recycle visible item', function() {
-        container.set('data', buildDataSet(2));
+      test('should update correct item on screen', function() {
+        container.set('data', buildDataSet(3));
         PolymerFlush();
         container.splice('data', 0, 1);
         PolymerFlush();
         container.set('data.0.index', 'correct');
         PolymerFlush();
         assert.equal(getFirstItemFromList(list).textContent, 'correct');
+        container.splice('data', 0, 1);
+        PolymerFlush();
+        container.set('data.0.index', 'correct again');
+        PolymerFlush();
+        assert.equal(getFirstItemFromList(list).textContent, 'correct again');
       });
+
     });
 
     suite('mutableData', function() {

--- a/test/mutations.html
+++ b/test/mutations.html
@@ -323,6 +323,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         PolymerFlush();
         assert.equal(getFirstItemFromList(list).textContent, 'correct');
       });
+
+      test('Issue #492: recycle visible item', function() {
+        container.set('data', buildDataSet(2));
+        PolymerFlush();
+        container.splice('data', 0, 1);
+        PolymerFlush();
+        container.set('data.0.index', 'correct');
+        PolymerFlush();
+        assert.equal(getFirstItemFromList(list).textContent, 'correct');
+      });
     });
 
     suite('mutableData', function() {

--- a/test/physical-count.html
+++ b/test/physical-count.html
@@ -24,8 +24,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/scroll-offset.html
+++ b/test/scroll-offset.html
@@ -47,8 +47,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </style>
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/selection.html
+++ b/test/selection.html
@@ -25,8 +25,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="trivialList">
     <template>

--- a/test/template-overload.html
+++ b/test/template-overload.html
@@ -22,8 +22,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </head>
 <body>
-  <!-- Issue: web-component-tester/issues/505 -->
-  <script>void(0)</script>
 
   <test-fixture id="defaultTemplateList">
     <template>


### PR DESCRIPTION
Fixes #492.
The polymer 1.x data binding system requires the templatizer implementor to keep track of the collection item keys, which iron-list does by saving those into `_physicalIndexForKey` object map.

This should be used to return the proper physical index (`_getPhysicalIndex` method), and during the forwarding of the properties to items (`_forwardItemPath` method); in particular, we have to consider the instance valid when its `__key__` matches the virtual index.

This handling was implemented up to iron-list 1.4.6, then got removed in 2.0 preview.