### PR TITLE
Don't use protocol relative src in grid demo

### DIFF
--- a/demo/grid.html
+++ b/demo/grid.html
@@ -187,7 +187,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div class="photoContainer">
             <div class="photoContent" tabindex$="[[tabIndex]]">
               <iron-image sizing="cover"
-                  src="//farm[[photo.farm]].staticflickr.com/[[photo.server]]/[[photo.id]]_[[photo.secret]]_n.jpg">
+                  src="https://farm[[photo.farm]].staticflickr.com/[[photo.server]]/[[photo.id]]_[[photo.secret]]_n.jpg">
               </iron-image>
               <div class="detail">[[photo.title]]</div>
             </div>


### PR DESCRIPTION
The [grid demo](https://raw-dot-custom-elements.appspot.com/PolymerElements/iron-list/v2.0.13/iron-list/demo/grid.html) is broken: the images are not displayed because the `src` value to the `iron-image` is protocol ralative. See https://github.com/PolymerElements/iron-image/issues/114

This pull request changes the `src` values to always use `https`.