### PR TITLE
updateViewportBoundaries on a visible list only

### DIFF
--- a/delta
+++ b/delta
@@ -1518,10 +1518,8 @@ Polymer$0({
       // clear cached visible index.
       this._firstVisibleIndexVal = null;
       this._lastVisibleIndexVal = null;
-      // Skip the resize event on touch devices when the address bar slides up.
-      var delta = Math.abs(this._viewportHeight - this._scrollTargetHeight);
-      this.updateViewportBoundaries();
       if (this._isVisible) {
+        this.updateViewportBoundaries();
         // Reinstall the scroll event listener.
         this.toggleScrollListener(true);
         this._resetAverage();


### PR DESCRIPTION
Solves a concurrency issue where the list can become hidden while _increasePoolIfNeeded is still scheduled. If this happens _isClientFull will always return false and all items are populated on the list.

This also removes an unused variable.